### PR TITLE
feat: add list-addresses cli command

### DIFF
--- a/proto/api/bria.proto
+++ b/proto/api/bria.proto
@@ -78,9 +78,8 @@ message Utxo {
 }
 
 message WalletAddress {
-  uint32 address_idx = 1;
-  string address = 2;
-  KeychainKind keychain_kind = 3;
+  string address = 1;
+  uint32 address_idx = 2;
 }
 
 message KeychainUtxos {

--- a/proto/api/bria.proto
+++ b/proto/api/bria.proto
@@ -65,7 +65,8 @@ message ListUtxosRequest {
 
 message ListAddressesRequest {
   string wallet_name = 1;
-  uint32 path = 2;
+  uint32 index_height = 2;
+  optional uint32 depth = 3;
 }
 
 message Utxo {

--- a/proto/api/bria.proto
+++ b/proto/api/bria.proto
@@ -77,6 +77,12 @@ message Utxo {
   optional uint32 block_height = 6;
 }
 
+message WalletAddress {
+  uint32 address_idx = 1;
+  string address = 2;
+  KeychainKind keychain_kind = 3;
+}
+
 message KeychainUtxos {
   string keychain_id = 1;
   repeated Utxo utxos = 2;
@@ -95,7 +101,7 @@ message ListUtxosResponse {
 
 message ListAddressesResponse {
   string wallet_id = 1;
-  repeated string addresses = 2;
+  repeated WalletAddress addresses = 2;
 }
 
 message GetWalletBalanceSummaryRequest {

--- a/proto/api/bria.proto
+++ b/proto/api/bria.proto
@@ -11,6 +11,7 @@ service BriaService {
   rpc GetWalletBalanceSummary (GetWalletBalanceSummaryRequest) returns (GetWalletBalanceSummaryResponse) {}
   rpc NewAddress (NewAddressRequest) returns (NewAddressResponse) {}
   rpc ListUtxos (ListUtxosRequest) returns (ListUtxosResponse) {}
+  rpc ListAddresses (ListAddressesRequest) returns (ListAddressesResponse) {}
   rpc CreateBatchGroup (CreateBatchGroupRequest) returns (CreateBatchGroupResponse) {}
   rpc QueuePayout (QueuePayoutRequest) returns (QueuePayoutResponse) {}
   rpc ListPayouts (ListPayoutsRequest) returns (ListPayoutsResponse) {}
@@ -62,6 +63,11 @@ message ListUtxosRequest {
   string wallet_name = 1;
 }
 
+message ListAddressesRequest {
+  string wallet_name = 1;
+  uint32 path = 2;
+}
+
 message Utxo {
   string outpoint = 1;
   uint32 address_idx = 2;
@@ -86,6 +92,11 @@ message ListUtxosResponse {
   repeated KeychainUtxos keychains = 2;
 }
 
+
+message ListAddressesResponse {
+  string wallet_id = 1;
+  repeated string addresses = 2;
+}
 
 message GetWalletBalanceSummaryRequest {
   string wallet_name = 1;

--- a/proto/api/bria.proto
+++ b/proto/api/bria.proto
@@ -65,8 +65,9 @@ message ListUtxosRequest {
 
 message ListAddressesRequest {
   string wallet_name = 1;
-  uint32 index_height = 2;
+  uint32 from_index = 2;
   optional uint32 depth = 3;
+  bool internal = 4;
 }
 
 message Utxo {

--- a/src/api/server/convert.rs
+++ b/src/api/server/convert.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use bdk::wallet::AddressInfo;
+
 use super::proto;
 use crate::{
     batch_group::*,
@@ -86,12 +88,11 @@ impl From<KeychainUtxos> for proto::KeychainUtxos {
     }
 }
 
-impl From<WalletAddress> for proto::WalletAddress {
-    fn from(w: WalletAddress) -> Self {
+impl From<AddressInfo> for proto::WalletAddress {
+    fn from(a: AddressInfo) -> Self {
         Self {
-            address_idx: w.address_idx,
-            address: w.address,
-            keychain_kind: w.keychain_kind as i32,
+            address: a.address.to_string(),
+            address_idx: a.index,
         }
     }
 }

--- a/src/api/server/convert.rs
+++ b/src/api/server/convert.rs
@@ -86,6 +86,16 @@ impl From<KeychainUtxos> for proto::KeychainUtxos {
     }
 }
 
+impl From<WalletAddress> for proto::WalletAddress {
+    fn from(w: WalletAddress) -> Self {
+        Self {
+            address_idx: w.address_idx,
+            address: w.address,
+            keychain_kind: w.keychain_kind as i32,
+        }
+    }
+}
+
 impl From<Payout> for proto::Payout {
     fn from(payout: Payout) -> Self {
         let destination = match payout.destination {

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -140,9 +140,12 @@ impl BriaService for Bria {
             .list_addresses(account_id, request.wallet_name, request.path)
             .await?;
 
+        let proto_addresses: Vec<proto::WalletAddress> =
+            addresses.into_iter().map(Into::into).collect();
+
         Ok(Response::new(ListAddressesResponse {
             wallet_id: wallet_id.to_string(),
-            addresses,
+            addresses: proto_addresses,
         }))
     }
 

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -140,8 +140,9 @@ impl BriaService for Bria {
             .list_addresses(
                 account_id,
                 request.wallet_name,
-                request.index_height,
+                request.from_index,
                 request.depth,
+                request.internal,
             )
             .await?;
 

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -137,7 +137,12 @@ impl BriaService for Bria {
         let request = request.into_inner();
         let (wallet_id, addresses) = self
             .app
-            .list_addresses(account_id, request.wallet_name, request.path)
+            .list_addresses(
+                account_id,
+                request.wallet_name,
+                request.index_height,
+                request.depth,
+            )
             .await?;
 
         let proto_addresses: Vec<proto::WalletAddress> =

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -128,6 +128,25 @@ impl BriaService for Bria {
     }
 
     #[instrument(skip_all, err)]
+    async fn list_addresses(
+        &self,
+        request: Request<ListAddressesRequest>,
+    ) -> Result<Response<ListAddressesResponse>, Status> {
+        let key = extract_api_token(&request)?;
+        let account_id = self.app.authenticate(key).await?;
+        let request = request.into_inner();
+        let (wallet_id, addresses) = self
+            .app
+            .list_addresses(account_id, request.wallet_name, request.path)
+            .await?;
+
+        Ok(Response::new(ListAddressesResponse {
+            wallet_id: wallet_id.to_string(),
+            addresses,
+        }))
+    }
+
+    #[instrument(skip_all, err)]
     async fn create_batch_group(
         &self,
         request: Request<CreateBatchGroupRequest>,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -229,7 +229,7 @@ impl App {
         println!("Index: {}, Depth: {:?}, ", index_height, depth);
 
         let end_index = index_height + 1;
-        let start_index = (end_index - depth.unwrap_or(20)).max(0);
+        let start_index = end_index.checked_sub(depth.unwrap_or(20)).unwrap_or(0);
         let mut addresses = Vec::new();
 
         for index in start_index..end_index {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -193,7 +193,6 @@ impl App {
         let wallet = self.wallets.find_by_name(account_id, wallet_name).await?;
         let keychain_wallet = wallet.current_keychain_wallet(&self.pool);
         let addr = keychain_wallet.new_external_address().await?;
-        println!("AddrInfo: {:?}", addr);
         Ok(addr.to_string())
     }
 
@@ -226,8 +225,6 @@ impl App {
         let wallet = self.wallets.find_by_name(account_id, wallet_name).await?;
         let keychain_wallet = wallet.current_keychain_wallet(&self.pool);
 
-        println!("Index: {}, Depth: {:?}, ", index_height, depth);
-
         let end_index = index_height + 1;
         let start_index = end_index.checked_sub(depth.unwrap_or(20)).unwrap_or(0);
         let mut addresses = Vec::new();
@@ -237,13 +234,6 @@ impl App {
             let address_info = keychain_wallet
                 .find_address_from_path(index, KeychainKind::External)
                 .await?;
-
-            println!(
-                "Index: {}, KeychainKind: {:?}, AddrInfo: {:?}",
-                index,
-                KeychainKind::External,
-                address_info
-            );
 
             addresses.push(address_info);
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,6 @@
 mod config;
 
-use bdk::KeychainKind;
+use bdk::{wallet::AddressInfo, KeychainKind};
 use sqlxmq::OwnedHandle;
 use tracing::instrument;
 
@@ -221,7 +221,7 @@ impl App {
         account_id: AccountId,
         wallet_name: String,
         path: u32,
-    ) -> Result<(WalletId, Vec<WalletAddress>), BriaError> {
+    ) -> Result<(WalletId, Vec<AddressInfo>), BriaError> {
         let wallet = self.wallets.find_by_name(account_id, wallet_name).await?;
         let keychain_wallet = wallet.current_keychain_wallet(&self.pool);
 
@@ -242,9 +242,7 @@ impl App {
                 address_info
             );
 
-            let wallet_address = WalletAddress::from(address_info);
-
-            addresses.push(wallet_address);
+            addresses.push(address_info);
         }
 
         Ok((wallet.id, addresses))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -220,13 +220,16 @@ impl App {
         &self,
         account_id: AccountId,
         wallet_name: String,
-        path: u32,
+        index_height: u32,
+        depth: Option<u32>,
     ) -> Result<(WalletId, Vec<AddressInfo>), BriaError> {
         let wallet = self.wallets.find_by_name(account_id, wallet_name).await?;
         let keychain_wallet = wallet.current_keychain_wallet(&self.pool);
 
-        let start_index = 0;
-        let end_index = path + 1;
+        println!("Index: {}, Depth: {:?}, ", index_height, depth);
+
+        let end_index = index_height + 1;
+        let start_index = (end_index - depth.unwrap_or(20)).max(0);
         let mut addresses = Vec::new();
 
         for index in start_index..end_index {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -226,7 +226,7 @@ impl App {
         let keychain_wallet = wallet.current_keychain_wallet(&self.pool);
 
         let end_index = index_height + 1;
-        let start_index = end_index.checked_sub(depth.unwrap_or(20)).unwrap_or(0);
+        let start_index = end_index.saturating_sub(depth.unwrap_or(20));
         let mut addresses = Vec::new();
 
         for index in start_index..end_index {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -221,7 +221,7 @@ impl App {
         account_id: AccountId,
         wallet_name: String,
         path: u32,
-    ) -> Result<(WalletId, Vec<String>), BriaError> {
+    ) -> Result<(WalletId, Vec<WalletAddress>), BriaError> {
         let wallet = self.wallets.find_by_name(account_id, wallet_name).await?;
         let keychain_wallet = wallet.current_keychain_wallet(&self.pool);
 
@@ -242,8 +242,9 @@ impl App {
                 address_info
             );
 
-            // Add the address to the list of addresses
-            addresses.push(address_info.to_string());
+            let wallet_address = WalletAddress::from(address_info);
+
+            addresses.push(wallet_address);
         }
 
         Ok((wallet.id, addresses))

--- a/src/cli/api_client.rs
+++ b/src/cli/api_client.rs
@@ -143,13 +143,15 @@ impl ApiClient {
     pub async fn list_addresses(
         &self,
         wallet: String,
-        index_height: u32,
+        from_index: u32,
         depth: Option<u32>,
+        internal: bool,
     ) -> anyhow::Result<()> {
         let request = tonic::Request::new(proto::ListAddressesRequest {
             wallet_name: wallet,
-            index_height,
+            from_index,
             depth,
+            internal,
         });
         let response = self
             .connect()

--- a/src/cli/api_client.rs
+++ b/src/cli/api_client.rs
@@ -140,10 +140,16 @@ impl ApiClient {
         output_json(response)
     }
 
-    pub async fn list_addresses(&self, wallet: String, path: u32) -> anyhow::Result<()> {
+    pub async fn list_addresses(
+        &self,
+        wallet: String,
+        index_height: u32,
+        depth: Option<u32>,
+    ) -> anyhow::Result<()> {
         let request = tonic::Request::new(proto::ListAddressesRequest {
             wallet_name: wallet,
-            path,
+            index_height,
+            depth,
         });
         let response = self
             .connect()

--- a/src/cli/api_client.rs
+++ b/src/cli/api_client.rs
@@ -140,6 +140,19 @@ impl ApiClient {
         output_json(response)
     }
 
+    pub async fn list_addresses(&self, wallet: String, path: u32) -> anyhow::Result<()> {
+        let request = tonic::Request::new(proto::ListAddressesRequest {
+            wallet_name: wallet,
+            path,
+        });
+        let response = self
+            .connect()
+            .await?
+            .list_addresses(self.inject_auth_token(request)?)
+            .await?;
+        output_json(response)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn create_batch_group(
         &self,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -162,7 +162,9 @@ enum Command {
         #[clap(short, long)]
         wallet: String,
         #[clap(short, long)]
-        path: u32,
+        index_height: u32,
+        #[clap(short, long)]
+        depth: Option<u32>,
     },
     CreateBatchGroup {
         #[clap(
@@ -362,10 +364,11 @@ pub async fn run() -> anyhow::Result<()> {
             url,
             api_key,
             wallet,
-            path,
+            index_height,
+            depth,
         } => {
             let client = api_client(url, api_key);
-            client.list_addresses(wallet, path).await?;
+            client.list_addresses(wallet, index_height, depth).await?;
         }
         Command::CreateBatchGroup {
             url,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,7 +4,7 @@ mod config;
 mod token_store;
 
 use anyhow::Context;
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand};
 use std::path::PathBuf;
 use url::Url;
 
@@ -162,9 +162,11 @@ enum Command {
         #[clap(short, long)]
         wallet: String,
         #[clap(short, long)]
-        index_height: u32,
+        from_index: u32,
         #[clap(short, long)]
         depth: Option<u32>,
+        #[clap(short, long, action = ArgAction::SetTrue)]
+        internal: bool,
     },
     CreateBatchGroup {
         #[clap(
@@ -364,11 +366,14 @@ pub async fn run() -> anyhow::Result<()> {
             url,
             api_key,
             wallet,
-            index_height,
+            from_index,
             depth,
+            internal,
         } => {
             let client = api_client(url, api_key);
-            client.list_addresses(wallet, index_height, depth).await?;
+            client
+                .list_addresses(wallet, from_index, depth, internal)
+                .await?;
         }
         Command::CreateBatchGroup {
             url,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -147,6 +147,23 @@ enum Command {
         #[clap(short, long)]
         wallet: String,
     },
+    /// List external addresses up to a given path index
+    ListAddresses {
+        #[clap(
+            short,
+            long,
+            value_parser,
+            default_value = "http://localhost:2742",
+            env = "BRIA_API_URL"
+        )]
+        url: Option<Url>,
+        #[clap(env = "BRIA_API_KEY", default_value = "")]
+        api_key: String,
+        #[clap(short, long)]
+        wallet: String,
+        #[clap(short, long)]
+        path: u32,
+    },
     CreateBatchGroup {
         #[clap(
             short,
@@ -340,6 +357,15 @@ pub async fn run() -> anyhow::Result<()> {
         } => {
             let client = api_client(url, api_key);
             client.list_utxos(wallet).await?;
+        }
+        Command::ListAddresses {
+            url,
+            api_key,
+            wallet,
+            path,
+        } => {
+            let client = api_client(url, api_key);
+            client.list_addresses(wallet, path).await?;
         }
         Command::CreateBatchGroup {
             url,

--- a/src/utxo/entity.rs
+++ b/src/utxo/entity.rs
@@ -1,22 +1,5 @@
 use crate::primitives::{bitcoin::*, *};
-use bdk::wallet::AddressInfo;
 use derive_builder::Builder;
-
-pub struct WalletAddress {
-    pub address_idx: u32,
-    pub address: String,
-    pub keychain_kind: KeychainKind,
-}
-
-impl From<AddressInfo> for WalletAddress {
-    fn from(p: AddressInfo) -> Self {
-        Self {
-            address_idx: p.index,
-            address: p.address.to_string(),
-            keychain_kind: p.keychain,
-        }
-    }
-}
 
 pub struct WalletUtxo {
     pub wallet_id: WalletId,

--- a/src/utxo/entity.rs
+++ b/src/utxo/entity.rs
@@ -1,5 +1,22 @@
 use crate::primitives::{bitcoin::*, *};
+use bdk::wallet::AddressInfo;
 use derive_builder::Builder;
+
+pub struct WalletAddress {
+    pub address_idx: u32,
+    pub address: String,
+    pub keychain_kind: KeychainKind,
+}
+
+impl From<AddressInfo> for WalletAddress {
+    fn from(p: AddressInfo) -> Self {
+        Self {
+            address_idx: p.index,
+            address: p.address.to_string(),
+            keychain_kind: p.keychain,
+        }
+    }
+}
 
 pub struct WalletUtxo {
     pub wallet_id: WalletId,


### PR DESCRIPTION
## Description

**_Note: This was an exercise in exploring the bdk lib and implementing something locally that was personally interesting. It may not be a desired change for the project._** 

This PR adds a new `list-addresses` command that lists the addresses for a wallet starting at the `--index-height` passed to the command. An optional `--depth` parameter is also included to limit or expand the number of addresses returned. The default depth is the gap limit (20).

### Future improvements

- [ ] I tried to make `--index-height` optional as well by defaulting to the wallet's current index, but I couldn't find an idempotent way to get this out of bdk

- [x] This by default returns from the external keychain. Future param/flag can be used to switch to internal keychain

### Usage examples

- `$ bria_cmd list-addresses -w default -f 16 -d 2`

  ```
  {
    "walletId": "a100b6db-4b5a-481e-906c-d4330a998ca0",
    "addresses": [
      {
        "address": "bcrt1qc2fu4fxfsdmg9rc0t4w0cme3vaf49u5yck9czz",
        "addressIdx": 15
      },
      {
        "address": "bcrt1qh5elx6tscywtrp6737kh2zme8m5rhmwk0ngeex",
        "addressIdx": 16
      }
    ]
  }
  ````

- `$ bria_cmd list-addresses -w default -f 16 -d 2 -i`

  ```
  {
    "walletId": "a100b6db-4b5a-481e-906c-d4330a998ca0",
    "addresses": [
      {
        "address": "bcrt1qmlvp0uels7r2s4h9jz43d8glmlq8larlzuwlwy",
        "addressIdx": 15
      },
      {
        "address": "bcrt1q9ztn6qjm6lcawmqpaz2dxr5xzyvqrhzh45au3f",
        "addressIdx": 16
      }
    ]
  }
  ````

- `$ bria_cmd list-addresses -w default -f 24`

  ```
  {
    "walletId": "a100b6db-4b5a-481e-906c-d4330a998ca0",
    "addresses": [
      {
        "address": "bcrt1qnm3f7q6nj6r98kqduzulx7yk4q3h9qtpzrnvwe",
        "addressIdx": 5
      },
      {
        "address": "bcrt1q7zazltwkmrtx676a6e05daa2s86mqf07kelmat",
        "addressIdx": 6
      },

      .
      .
      .

      {
        "address": "bcrt1qzvqllfxqez75uznr225a5czsmwg9rcd7dxdlqp",
        "addressIdx": 23
      },
      {
        "address": "bcrt1qztjl4ue7ed6szv2zjv7eavsq0qf3l2hvtq4f7l",
        "addressIdx": 24
      }
    ]
  }
  ```