### PR TITLE
feat: add metadata argument to queue_payout cli & grpc interfaces

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -12,6 +12,8 @@ jobs:
     name: Check Code
     runs-on: ubuntu-latest
     steps:
+      - name: Install protoc dependencies for prost-wkt-types
+        run: sudo apt-get install -y protobuf-compiler libprotobuf-dev
       - uses: actions/checkout@v3
       - name: Run check code
         run: make check-code

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,7 +2,7 @@ name: "E2E Tests"
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   integration:
@@ -13,6 +13,8 @@ jobs:
         uses: mig4/setup-bats@v1
         with:
           bats-version: 1.9.0
+      - name: Install protoc dependencies for prost-wkt-types
+        run: sudo apt-get install -y protobuf-compiler libprotobuf-dev
       - uses: actions/checkout@v3
       - name: Setup cache for cargo
         uses: actions/cache@v3
@@ -28,4 +30,3 @@ jobs:
         env:
           PG_CON: postgres://user:password@127.0.0.1:5432/pg
         run: make e2e
-

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -2,13 +2,15 @@ name: "Integration Tests"
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   integration:
     name: Integration Test
     runs-on: ubuntu-latest
     steps:
+      - name: Install protoc dependencies for prost-wkt-types
+        run: sudo apt-get install -y protobuf-compiler libprotobuf-dev
       - uses: actions/checkout@v3
       - name: Install sqlx-cli
         uses: baptiste0928/cargo-install@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,8 +2126,7 @@ dependencies = [
 [[package]]
 name = "prost-wkt"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f82196110c6376d25bf155f6d3a55835151d4f8ad470f203d46ee04c040d2fb"
+source = "git+https://github.com/bodymindarts/prost-wkt?branch=vendored-protoc-feature#9edf7f5e8ba669d9459ee0372d3036c3a122c31b"
 dependencies = [
  "chrono",
  "inventory",
@@ -2141,8 +2140,7 @@ dependencies = [
 [[package]]
 name = "prost-wkt-build"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8958d27269aec14c99c134ebb2796ab4287478bde21453d76aa43d1683265759"
+source = "git+https://github.com/bodymindarts/prost-wkt?branch=vendored-protoc-feature#9edf7f5e8ba669d9459ee0372d3036c3a122c31b"
 dependencies = [
  "heck 0.4.1",
  "prost 0.11.8",
@@ -2154,8 +2152,7 @@ dependencies = [
 [[package]]
 name = "prost-wkt-types"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c174ca3ca389b401547913b2a92aa9c08d849499138f962a771aedc9d77b2ce"
+source = "git+https://github.com/bodymindarts/prost-wkt?branch=vendored-protoc-feature#9edf7f5e8ba669d9459ee0372d3036c3a122c31b"
 dependencies = [
  "chrono",
  "prost 0.11.8",
@@ -2163,6 +2160,7 @@ dependencies = [
  "prost-types 0.11.8",
  "prost-wkt",
  "prost-wkt-build",
+ "protobuf-src",
  "regex",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "prost 0.11.8",
+ "prost-wkt-types",
  "protobuf-src",
  "rand",
  "reqwest",
@@ -712,6 +713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
+dependencies = [
+ "quote",
+ "syn 2.0.12",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1170,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -1403,6 +1434,16 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "inventory"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7741301a6d6a9b28ce77c0fb77a4eb116b6bc8f3bef09923f7743d059c4157d3"
+dependencies = [
+ "ctor",
+ "ghost",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -2080,6 +2121,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
  "prost 0.11.8",
+]
+
+[[package]]
+name = "prost-wkt"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f82196110c6376d25bf155f6d3a55835151d4f8ad470f203d46ee04c040d2fb"
+dependencies = [
+ "chrono",
+ "inventory",
+ "prost 0.11.8",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "typetag",
+]
+
+[[package]]
+name = "prost-wkt-build"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8958d27269aec14c99c134ebb2796ab4287478bde21453d76aa43d1683265759"
+dependencies = [
+ "heck 0.4.1",
+ "prost 0.11.8",
+ "prost-build 0.11.8",
+ "prost-types 0.11.8",
+ "quote",
+]
+
+[[package]]
+name = "prost-wkt-types"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c174ca3ca389b401547913b2a92aa9c08d849499138f962a771aedc9d77b2ce"
+dependencies = [
+ "chrono",
+ "prost 0.11.8",
+ "prost-build 0.11.8",
+ "prost-types 0.11.8",
+ "prost-wkt",
+ "prost-wkt-build",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -3385,6 +3472,30 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "typetag"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc3ebbaab23e6cc369cb48246769d031f5bd85f1b28141f32982e3c0c7b33cf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb01b60fcc3f5e17babb1a9956263f3ccd2cadc3e52908400231441683283c1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.37"
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
 prost = "0.11"
-prost-wkt-types = "0.4.1"
+prost-wkt-types = { git = "https://github.com/bodymindarts/prost-wkt", branch = "vendored-protoc-feature", package = "prost-wkt-types", features = ["vendored-protoc"]}
 rust_decimal_macros = "1.29.1"
 rusty-money = "0.4.1"
 thiserror = "1.0.37"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tracing = "0.1.37"
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
 prost = "0.11"
+prost-wkt-types = "0.4.1"
 rust_decimal_macros = "1.29.1"
 rusty-money = "0.4.1"
 thiserror = "1.0.37"

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .type_attribute(".", "#[derive(serde::Serialize)]")
         .type_attribute(".", "#[serde(rename_all = \"camelCase\")]")
+        .extern_path(".google.protobuf.Struct", "::prost_wkt_types::Struct")
         .compile(&["proto/api/bria.proto"], &["proto"])?;
 
     tonic_build::configure()

--- a/proto/api/bria.proto
+++ b/proto/api/bria.proto
@@ -170,7 +170,7 @@ message QueuePayoutRequest {
     string onchain_address = 3;
   };
   uint64 satoshis = 4;
-  google.protobuf.Struct metadata = 5;
+  optional google.protobuf.Struct metadata = 5;
 }
 
 message QueuePayoutResponse {

--- a/proto/api/bria.proto
+++ b/proto/api/bria.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
+
 package services.bria.v1;
 
 option go_package = "github.com/GaloyMoney/terraform-provider-bria/client/proto/briav1";
@@ -168,6 +170,7 @@ message QueuePayoutRequest {
     string onchain_address = 3;
   };
   uint64 satoshis = 4;
+  google.protobuf.Struct metadata = 5;
 }
 
 message QueuePayoutResponse {

--- a/src/api/server/convert.rs
+++ b/src/api/server/convert.rs
@@ -14,7 +14,12 @@ use crate::{
 
 impl From<BriaError> for tonic::Status {
     fn from(err: BriaError) -> Self {
-        tonic::Status::new(tonic::Code::Unknown, format!("{err}"))
+        match err {
+            BriaError::CouldNotParseIncomingMetadata(err) => {
+                tonic::Status::invalid_argument(err.to_string())
+            }
+            _ => tonic::Status::new(tonic::Code::Unknown, format!("{err}")),
+        }
     }
 }
 

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -209,6 +209,13 @@ impl BriaService for Bria {
             metadata,
         } = request;
 
+        let metadata_json = metadata
+            .map(serde_json::to_value)
+            .transpose()
+            .map_err(|_| {
+                Status::invalid_argument("'metadata' argument could not be converted to JSON")
+            })?;
+
         let id = self
             .app
             .queue_payout(
@@ -218,7 +225,7 @@ impl BriaService for Bria {
                 destination.try_into()?,
                 Satoshis::from(satoshis),
                 None,
-                metadata.map(|metadata| serde_json::to_value(metadata).unwrap()),
+                metadata_json,
             )
             .await?;
         Ok(Response::new(QueuePayoutResponse { id: id.to_string() }))

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -206,6 +206,7 @@ impl BriaService for Bria {
             batch_group_name,
             destination,
             satoshis,
+            metadata,
         } = request;
 
         let id = self
@@ -217,7 +218,7 @@ impl BriaService for Bria {
                 destination.try_into()?,
                 Satoshis::from(satoshis),
                 None,
-                None,
+                metadata.map(|metadata| serde_json::to_value(metadata).unwrap()),
             )
             .await?;
         Ok(Response::new(QueuePayoutResponse { id: id.to_string() }))

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -212,9 +212,7 @@ impl BriaService for Bria {
         let metadata_json = metadata
             .map(serde_json::to_value)
             .transpose()
-            .map_err(|_| {
-                Status::invalid_argument("'metadata' argument could not be converted to JSON")
-            })?;
+            .map_err(BriaError::CouldNotParseIncomingMetadata)?;
 
         let id = self
             .app

--- a/src/cli/api_client.rs
+++ b/src/cli/api_client.rs
@@ -231,6 +231,8 @@ impl ApiClient {
         satoshis: u64,
         metadata: serde_json::Value,
     ) -> anyhow::Result<()> {
+        let metadata_struct = serde_json::from_value(metadata)?;
+
         let request = tonic::Request::new(proto::QueuePayoutRequest {
             wallet_name,
             batch_group_name,
@@ -238,7 +240,7 @@ impl ApiClient {
                 on_chain_address,
             )),
             satoshis,
-            metadata: Some(serde_json::from_value(metadata).unwrap()),
+            metadata: Some(metadata_struct),
         });
         let response = self
             .connect()

--- a/src/cli/api_client.rs
+++ b/src/cli/api_client.rs
@@ -231,7 +231,6 @@ impl ApiClient {
         satoshis: u64,
         metadata: serde_json::Value,
     ) -> anyhow::Result<()> {
-        println!("HERE: {:?}", metadata);
         let request = tonic::Request::new(proto::QueuePayoutRequest {
             wallet_name,
             batch_group_name,
@@ -239,6 +238,7 @@ impl ApiClient {
                 on_chain_address,
             )),
             satoshis,
+            metadata: Some(serde_json::from_value(metadata).unwrap()),
         });
         let response = self
             .connect()

--- a/src/cli/api_client.rs
+++ b/src/cli/api_client.rs
@@ -231,9 +231,6 @@ impl ApiClient {
         satoshis: u64,
         metadata: Option<serde_json::Value>,
     ) -> anyhow::Result<()> {
-        let metadata_struct: Option<prost_wkt_types::Struct> =
-            metadata.map(serde_json::from_value).transpose()?;
-
         let request = tonic::Request::new(proto::QueuePayoutRequest {
             wallet_name,
             batch_group_name,
@@ -241,7 +238,7 @@ impl ApiClient {
                 on_chain_address,
             )),
             satoshis,
-            metadata: metadata_struct,
+            metadata: metadata.map(serde_json::from_value).transpose()?,
         });
         let response = self
             .connect()

--- a/src/cli/api_client.rs
+++ b/src/cli/api_client.rs
@@ -229,7 +229,9 @@ impl ApiClient {
         batch_group_name: String,
         on_chain_address: String,
         satoshis: u64,
+        metadata: serde_json::Value,
     ) -> anyhow::Result<()> {
+        println!("HERE: {:?}", metadata);
         let request = tonic::Request::new(proto::QueuePayoutRequest {
             wallet_name,
             batch_group_name,

--- a/src/cli/api_client.rs
+++ b/src/cli/api_client.rs
@@ -229,9 +229,10 @@ impl ApiClient {
         batch_group_name: String,
         on_chain_address: String,
         satoshis: u64,
-        metadata: serde_json::Value,
+        metadata: Option<serde_json::Value>,
     ) -> anyhow::Result<()> {
-        let metadata_struct = serde_json::from_value(metadata)?;
+        let metadata_struct: Option<prost_wkt_types::Struct> =
+            metadata.map(serde_json::from_value).transpose()?;
 
         let request = tonic::Request::new(proto::QueuePayoutRequest {
             wallet_name,
@@ -240,7 +241,7 @@ impl ApiClient {
                 on_chain_address,
             )),
             satoshis,
-            metadata: Some(metadata_struct),
+            metadata: metadata_struct,
         });
         let response = self
             .connect()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -245,6 +245,8 @@ enum Command {
         destination: String,
         #[clap(short, long)]
         amount: u64,
+        #[clap(short, long, value_parser = parse_json)]
+        metadata: serde_json::Value,
     },
     /// List pending Payouts
     ListPayouts {
@@ -449,10 +451,11 @@ pub async fn run() -> anyhow::Result<()> {
             group_name,
             destination,
             amount,
+            metadata,
         } => {
             let client = api_client(cli.bria_home, url, api_key);
             client
-                .queue_payout(wallet, group_name, destination, amount)
+                .queue_payout(wallet, group_name, destination, amount, metadata)
                 .await?;
         }
         Command::ListPayouts {
@@ -528,4 +531,8 @@ fn read_to_base64(path: PathBuf) -> anyhow::Result<String> {
     reader.read_to_end(&mut buffer)?;
     use base64::{engine::general_purpose, Engine};
     Ok(general_purpose::STANDARD.encode(buffer))
+}
+
+fn parse_json(src: &str) -> Result<serde_json::Value, serde_json::Error> {
+    serde_json::from_str(src)
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -246,7 +246,7 @@ enum Command {
         #[clap(short, long)]
         amount: u64,
         #[clap(short, long, value_parser = parse_json)]
-        metadata: serde_json::Value,
+        metadata: Option<serde_json::Value>,
     },
     /// List pending Payouts
     ListPayouts {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -533,6 +533,6 @@ fn read_to_base64(path: PathBuf) -> anyhow::Result<String> {
     Ok(general_purpose::STANDARD.encode(buffer))
 }
 
-fn parse_json(src: &str) -> Result<serde_json::Value, serde_json::Error> {
-    serde_json::from_str(src)
+fn parse_json(src: &str) -> anyhow::Result<serde_json::Value> {
+    Ok(serde_json::from_str(src)?)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,8 @@ pub enum BriaError {
     FeeEstimation(reqwest::Error),
     #[error("BriaError - CouldNotCombinePsbts: {0}")]
     CouldNotCombinePsbts(psbt::Error),
+    #[error("BriaError - CouldNotParseIncomingMetadata: {0}")]
+    CouldNotParseIncomingMetadata(serde_json::Error),
 }
 
 impl JobExecutionError for BriaError {}

--- a/tests/e2e/payout.bats
+++ b/tests/e2e/payout.bats
@@ -37,7 +37,7 @@ teardown_file() {
 @test "payout: Create batch group and have two queued payouts on it" {
   bria_cmd create-batch-group --name high --interval-trigger 5
   bria_cmd queue-payout --wallet default --group-name high --destination bcrt1q208tuy5rd3kvy8xdpv6yrczg7f3mnlk3lql7ej --amount 75000000
-  bria_cmd queue-payout --wallet default --group-name high --destination bcrt1q3rr02wkkvkwcj7h0nr9dqr9z3z3066pktat7kv --amount 75000000
+  bria_cmd queue-payout --wallet default --group-name high --destination bcrt1q3rr02wkkvkwcj7h0nr9dqr9z3z3066pktat7kv --amount 75000000 --metadata '{"foo":{"bar":"baz"}}'
 
   n_payouts=$(bria_cmd list-payouts -w default | jq '.payouts | length')
   [[ "${n_payouts}" == "2" ]] || exit 1


### PR DESCRIPTION
## Description

This PR facilitates:

- taking a google.protobuf.Struct object in the grpc interface for the QueuePayout request which can be serialized/deserialized to json

- taking a json string in for the queue_payout command's metadata argument in the cli and passing it through to the grpc interface

## TODO
- [ ] decide if we'd also like to add an arg that takes a `std::path::PathBuf` of a json file