### PR TITLE
feat: add 'bitcoind' signer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ fail-on-warnings = []
 sqlx-ledger = { version = "0.7.7", features = ["otel"] }
 
 anyhow = "1.0.71"
+bitcoincore-rpc = "0.16.0"
 clap = { version = "4.2", features = ["derive", "env"] }
 chrono = { version = "0.4.22", features = ["clock", "serde"], default-features = false }
 derive_builder = "0.12.0"
@@ -50,6 +51,3 @@ tempfile = "3.4.0"
 [build-dependencies]
 protobuf-src = { version = "1.1.0" }
 tonic-build = { version = "0.9", features = ["prost"] }
-
-[dev-dependencies]
-bitcoincore-rpc = "0.16.0"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,6 +10,9 @@ services:
   bitcoind:
     ports:
       - "18443:18443"
+  bitcoind-signer:
+    ports:
+      - "18543:18443"
   lnd:
     ports:
       - "10009:10009"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     depends_on:
       - postgres
       - bitcoind
+      - bitcoind-signer
       - lnd
       - otel-agent
       - fulcrum
@@ -68,6 +69,15 @@ services:
     image: lncm/bitcoind:v24.0.1
     volumes:
       - ${HOST_PROJECT_PATH:-.}/dev/bitcoind/bitcoin.conf:/data/.bitcoin/bitcoin.conf
+  bitcoind-signer:
+    image: lncm/bitcoind:v24.0.1
+    volumes:
+      - ${HOST_PROJECT_PATH:-.}/dev/bitcoind/bitcoin.conf:/data/.bitcoin/bitcoin.conf
+    depends_on: [ bitcoind ]
+    entrypoint: [ "/bin/sh", "-c" ]
+    command:
+      - |
+        bitcoind -connect=bitcoind:18444
   lnd:
     image: lightninglabs/lnd:v0.15.4-beta
     volumes:

--- a/proto/api/bria.proto
+++ b/proto/api/bria.proto
@@ -67,6 +67,7 @@ message SetSignerConfigRequest {
   string xpub_ref = 1;
   oneof config {
     LndSignerConfig lnd = 2;
+    BitcoindSignerConfig bitcoind = 3;
   }
 }
 
@@ -74,6 +75,12 @@ message LndSignerConfig {
   string endpoint = 1;
   string cert_base64 = 2;
   string macaroon_base64 = 3;
+}
+
+message BitcoindSignerConfig {
+  string endpoint = 1;
+  string rpc_user = 2;
+  string rpc_password = 3;
 }
 
 message SetSignerConfigResponse {}

--- a/src/api/server/convert.rs
+++ b/src/api/server/convert.rs
@@ -52,6 +52,13 @@ impl TryFrom<Option<proto::set_signer_config_request::Config>> for SignerConfig 
                     macaroon_base64: config.macaroon_base64,
                 }))
             }
+            Some(proto::set_signer_config_request::Config::Bitcoind(config)) => {
+                Ok(SignerConfig::Bitcoind(BitcoindSignerConfig {
+                    endpoint: config.endpoint,
+                    rpc_user: config.rpc_user,
+                    rpc_password: config.rpc_password,
+                }))
+            }
             None => Err(tonic::Status::new(
                 tonic::Code::InvalidArgument,
                 "missing signer config",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,8 @@ use url::Url;
 use crate::primitives::TxPriority;
 use config::*;
 
+use self::api_client::SignerConfig;
+
 #[derive(Parser)]
 #[clap(version, long_about = None)]
 struct Cli {
@@ -338,6 +340,14 @@ enum SetSignerConfigCommand {
         #[clap(short, long)]
         cert_file: PathBuf,
     },
+    Bitcoind {
+        #[clap(short, long)]
+        endpoint: String,
+        #[clap(short = 'u', long)]
+        rpc_user: String,
+        #[clap(short = 'p', long)]
+        rpc_password: String,
+    },
 }
 
 pub async fn run() -> anyhow::Result<()> {
@@ -430,11 +440,27 @@ pub async fn run() -> anyhow::Result<()> {
                     client
                         .set_signer_config(
                             xpub,
-                            crate::api::proto::LndSignerConfig {
+                            SignerConfig::Lnd(crate::api::proto::LndSignerConfig {
                                 endpoint,
                                 macaroon_base64,
                                 cert_base64,
-                            },
+                            }),
+                        )
+                        .await?;
+                }
+                SetSignerConfigCommand::Bitcoind {
+                    endpoint,
+                    rpc_user,
+                    rpc_password,
+                } => {
+                    client
+                        .set_signer_config(
+                            xpub,
+                            SignerConfig::Bitcoind(crate::api::proto::BitcoindSignerConfig {
+                                endpoint,
+                                rpc_user,
+                                rpc_password,
+                            }),
                         )
                         .await?;
                 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -66,6 +66,7 @@ pub mod bitcoin {
             },
             consensus,
             hash_types::Txid,
+            hashes::hex,
             util::{
                 address::Error as AddressError,
                 bip32::{self, DerivationPath, ExtendedPubKey, Fingerprint},

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -71,7 +71,7 @@ pub mod bitcoin {
                 bip32::{self, DerivationPath, ExtendedPubKey, Fingerprint},
                 psbt,
             },
-            Address, Network,
+            Address, EcdsaSighashType, Network,
         },
         BlockTime, KeychainKind,
     };

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -71,7 +71,7 @@ pub mod bitcoin {
                 bip32::{self, DerivationPath, ExtendedPubKey, Fingerprint},
                 psbt,
             },
-            Address, EcdsaSighashType, Network,
+            Address, Network,
         },
         BlockTime, KeychainKind,
     };

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -66,13 +66,12 @@ pub mod bitcoin {
             },
             consensus,
             hash_types::Txid,
-            hashes::hex,
             util::{
                 address::Error as AddressError,
                 bip32::{self, DerivationPath, ExtendedPubKey, Fingerprint},
                 psbt,
             },
-            Address, Network,
+            Address, EcdsaSighashType, Network,
         },
         BlockTime, KeychainKind,
     };

--- a/src/wallet/psbt_builder.rs
+++ b/src/wallet/psbt_builder.rs
@@ -15,6 +15,8 @@ use crate::{
     primitives::{bitcoin::*, *},
 };
 
+pub const DEFAULT_SIGHASH_TYPE: psbt::PsbtSighashType = bdk::bitcoin::EcdsaSighashType::All.into();
+
 type Payout = (uuid::Uuid, bitcoin::Address, Satoshis);
 pub struct WalletTotals {
     pub wallet_id: WalletId,
@@ -211,7 +213,7 @@ impl BdkWalletVisitor for PsbtBuilder<AcceptingDeprecatedKeychainState> {
         }
         builder
             .fee_rate(self.fee_rate.expect("fee rate must be set"))
-            .sighash(bdk::bitcoin::EcdsaSighashType::All.into())
+            .sighash(DEFAULT_SIGHASH_TYPE)
             .drain_wallet()
             .drain_to(drain_address.script_pubkey());
         match builder.finish() {
@@ -286,7 +288,7 @@ impl BdkWalletVisitor for PsbtBuilder<AcceptingCurrentKeychainState> {
         }
         builder.fee_rate(self.fee_rate.expect("fee rate must be set"));
         builder.drain_to(change_address.script_pubkey());
-        builder.sighash(bdk::bitcoin::EcdsaSighashType::All.into());
+        builder.sighash(DEFAULT_SIGHASH_TYPE);
 
         let mut total_output_satoshis = Satoshis::from(0);
         for (payout_id, destination, satoshis) in self.current_payouts.drain(..max_payout) {

--- a/src/wallet/psbt_builder.rs
+++ b/src/wallet/psbt_builder.rs
@@ -15,7 +15,8 @@ use crate::{
     primitives::{bitcoin::*, *},
 };
 
-pub const DEFAULT_SIGHASH_TYPE: psbt::PsbtSighashType = bdk::bitcoin::EcdsaSighashType::All.into();
+pub const DEFAULT_SIGHASH_TYPE: bdk::bitcoin::EcdsaSighashType =
+    bdk::bitcoin::EcdsaSighashType::All;
 
 type Payout = (uuid::Uuid, bitcoin::Address, Satoshis);
 pub struct WalletTotals {
@@ -213,7 +214,7 @@ impl BdkWalletVisitor for PsbtBuilder<AcceptingDeprecatedKeychainState> {
         }
         builder
             .fee_rate(self.fee_rate.expect("fee rate must be set"))
-            .sighash(DEFAULT_SIGHASH_TYPE)
+            .sighash(DEFAULT_SIGHASH_TYPE.into())
             .drain_wallet()
             .drain_to(drain_address.script_pubkey());
         match builder.finish() {
@@ -288,7 +289,7 @@ impl BdkWalletVisitor for PsbtBuilder<AcceptingCurrentKeychainState> {
         }
         builder.fee_rate(self.fee_rate.expect("fee rate must be set"));
         builder.drain_to(change_address.script_pubkey());
-        builder.sighash(DEFAULT_SIGHASH_TYPE);
+        builder.sighash(DEFAULT_SIGHASH_TYPE.into());
 
         let mut total_output_satoshis = Satoshis::from(0);
         for (payout_id, destination, satoshis) in self.current_payouts.drain(..max_payout) {

--- a/src/xpub/entity.rs
+++ b/src/xpub/entity.rs
@@ -8,6 +8,7 @@ use crate::{entity::*, primitives::*};
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SignerConfig {
     Lnd(LndSignerConfig),
+    Bitcoind(BitcoindSignerConfig),
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/xpub/entity.rs
+++ b/src/xpub/entity.rs
@@ -69,7 +69,11 @@ impl AccountXPub {
                 let client = LndRemoteSigner::connect(cfg).await?;
                 Some(Box::new(client) as Box<dyn RemoteSigningClient + 'static>)
             }
-            _ => None,
+            Some(SignerConfig::Bitcoind(ref cfg)) => {
+                let client = BitcoindRemoteSigner::connect(cfg).await?;
+                Some(Box::new(client) as Box<dyn RemoteSigningClient + 'static>)
+            }
+            None => None,
         };
         Ok(client)
     }

--- a/src/xpub/signing_client/bitcoind.rs
+++ b/src/xpub/signing_client/bitcoind.rs
@@ -1,0 +1,53 @@
+use async_trait::async_trait;
+use bitcoincore_rpc::{Auth, Client, RpcApi};
+use serde::{Deserialize, Serialize};
+
+use super::{error::*, r#trait::*};
+use crate::primitives::bitcoin::{consensus, hex::FromHex, psbt};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BitcoindSignerConfig {
+    pub endpoint: String,
+    pub rpc_user: String,
+    pub rpc_password: String,
+}
+
+pub struct BitcoindRemoteSigner {
+    inner: bitcoincore_rpc::Client,
+}
+
+impl BitcoindRemoteSigner {
+    pub async fn connect(cfg: &BitcoindSignerConfig) -> Result<Self, SigningClientError> {
+        let auth = Auth::UserPass(cfg.rpc_user.to_string(), cfg.rpc_password.to_string());
+        let client = Client::new(&cfg.endpoint.to_string(), auth).map_err(|e| {
+            SigningClientError::CouldNotConnect(format!("Failed to connect to bitcoind: {e}"))
+        })?;
+
+        Ok(Self { inner: client })
+    }
+}
+
+#[async_trait]
+impl RemoteSigningClient for BitcoindRemoteSigner {
+    async fn sign_psbt(
+        &mut self,
+        psbt: &psbt::PartiallySignedTransaction,
+    ) -> Result<psbt::PartiallySignedTransaction, SigningClientError> {
+        let raw_psbt = consensus::encode::serialize(&psbt);
+        let hex_psbt = base64::encode(raw_psbt);
+
+        let response = self
+            .inner
+            .wallet_process_psbt(&hex_psbt, None, None, None)
+            .map_err(|e| {
+                SigningClientError::RemoteCallFailure(format!(
+                    "Failed to sign psbt via bitcoind: {e}"
+                ))
+            })?;
+
+        let signed_psbt = Vec::<u8>::from_hex(&response.psbt).map_err(|e| {
+            SigningClientError::HexConvert(format!("Failed to convert psbt from bitcoind: {e}"))
+        })?;
+        Ok(consensus::encode::deserialize(&signed_psbt)?)
+    }
+}

--- a/src/xpub/signing_client/bitcoind.rs
+++ b/src/xpub/signing_client/bitcoind.rs
@@ -4,7 +4,10 @@ use bitcoincore_rpc::{Auth, Client, RpcApi};
 use serde::{Deserialize, Serialize};
 
 use super::{error::*, r#trait::*};
-use crate::primitives::bitcoin::{consensus, psbt, EcdsaSighashType};
+use crate::{
+    primitives::bitcoin::{consensus, psbt},
+    wallet::DEFAULT_SIGHASH_TYPE,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BitcoindSignerConfig {
@@ -37,7 +40,7 @@ impl RemoteSigningClient for BitcoindRemoteSigner {
         let raw_psbt = consensus::encode::serialize(&psbt);
         let hex_psbt = general_purpose::STANDARD.encode(raw_psbt);
 
-        let sighash_type = Some(EcdsaSighashType::All.into());
+        let sighash_type = Some(DEFAULT_SIGHASH_TYPE);
         let response = self
             .inner
             .wallet_process_psbt(&hex_psbt, None, sighash_type, None)

--- a/src/xpub/signing_client/bitcoind.rs
+++ b/src/xpub/signing_client/bitcoind.rs
@@ -1,10 +1,11 @@
 use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine};
+use bdk::bitcoin::EcdsaSighashType;
 use bitcoincore_rpc::{Auth, Client, RpcApi};
 use serde::{Deserialize, Serialize};
 
 use super::{error::*, r#trait::*};
-use crate::primitives::bitcoin::{consensus, psbt, EcdsaSighashType};
+use crate::primitives::bitcoin::{consensus, psbt};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BitcoindSignerConfig {
@@ -37,7 +38,7 @@ impl RemoteSigningClient for BitcoindRemoteSigner {
         let raw_psbt = consensus::encode::serialize(&psbt);
         let hex_psbt = general_purpose::STANDARD.encode(raw_psbt);
 
-        let sighash_type = Some(EcdsaSighashType::All.into());
+        let sighash_type = Some(first_sighash_to_ecdsa_sighash(psbt)?.into());
         let response = self
             .inner
             .wallet_process_psbt(&hex_psbt, None, sighash_type, None)
@@ -54,4 +55,21 @@ impl RemoteSigningClient for BitcoindRemoteSigner {
             })?;
         Ok(consensus::encode::deserialize(&signed_psbt)?)
     }
+}
+
+fn first_sighash_to_ecdsa_sighash(
+    psbt: &psbt::PartiallySignedTransaction,
+) -> Result<EcdsaSighashType, SigningClientError> {
+    psbt.inputs
+        .iter()
+        .filter_map(|input| {
+            input
+                .sighash_type
+                .map(|sighash_type| EcdsaSighashType::from_standard(sighash_type.to_u32()))
+        })
+        .next()
+        .unwrap_or(Ok(EcdsaSighashType::All))
+        .map_err(|e| {
+            SigningClientError::SighashParse(format!("Failed to parse sighash from psbt: {e}"))
+        })
 }

--- a/src/xpub/signing_client/bitcoind.rs
+++ b/src/xpub/signing_client/bitcoind.rs
@@ -40,7 +40,7 @@ impl RemoteSigningClient for BitcoindRemoteSigner {
         let raw_psbt = consensus::encode::serialize(&psbt);
         let hex_psbt = general_purpose::STANDARD.encode(raw_psbt);
 
-        let sighash_type = Some(DEFAULT_SIGHASH_TYPE);
+        let sighash_type = Some(DEFAULT_SIGHASH_TYPE.into());
         let response = self
             .inner
             .wallet_process_psbt(&hex_psbt, None, sighash_type, None)

--- a/src/xpub/signing_client/bitcoind.rs
+++ b/src/xpub/signing_client/bitcoind.rs
@@ -35,7 +35,7 @@ impl RemoteSigningClient for BitcoindRemoteSigner {
         psbt: &psbt::PartiallySignedTransaction,
     ) -> Result<psbt::PartiallySignedTransaction, SigningClientError> {
         let raw_psbt = consensus::encode::serialize(&psbt);
-        let hex_psbt = general_purpose::STANDARD_NO_PAD.encode(raw_psbt);
+        let hex_psbt = general_purpose::STANDARD.encode(raw_psbt);
 
         let sighash_type = Some(EcdsaSighashType::All.into());
         let response = self
@@ -47,7 +47,7 @@ impl RemoteSigningClient for BitcoindRemoteSigner {
                 ))
             })?;
 
-        let signed_psbt = general_purpose::STANDARD_NO_PAD
+        let signed_psbt = general_purpose::STANDARD
             .decode(response.psbt)
             .map_err(|e| {
                 SigningClientError::HexConvert(format!("Failed to convert psbt from bitcoind: {e}"))

--- a/src/xpub/signing_client/error.rs
+++ b/src/xpub/signing_client/error.rs
@@ -12,6 +12,8 @@ pub enum SigningClientError {
     Encode(#[from] consensus::encode::Error),
     #[error("SigningClientError - Decode: {0}")]
     Decode(#[from] base64::DecodeError),
+    #[error("SigningClientError - HexDecode: {0}")]
+    HexConvert(String),
     #[error("SigningClientError - IO: {0}")]
     IO(#[from] std::io::Error),
 }

--- a/src/xpub/signing_client/error.rs
+++ b/src/xpub/signing_client/error.rs
@@ -14,8 +14,6 @@ pub enum SigningClientError {
     Decode(#[from] base64::DecodeError),
     #[error("SigningClientError - HexDecode: {0}")]
     HexConvert(String),
-    #[error("SigningClientError - SighashParse: {0}")]
-    SighashParse(String),
     #[error("SigningClientError - IO: {0}")]
     IO(#[from] std::io::Error),
 }

--- a/src/xpub/signing_client/error.rs
+++ b/src/xpub/signing_client/error.rs
@@ -14,6 +14,8 @@ pub enum SigningClientError {
     Decode(#[from] base64::DecodeError),
     #[error("SigningClientError - HexDecode: {0}")]
     HexConvert(String),
+    #[error("SigningClientError - SighashParse: {0}")]
+    SighashParse(String),
     #[error("SigningClientError - IO: {0}")]
     IO(#[from] std::io::Error),
 }

--- a/src/xpub/signing_client/mod.rs
+++ b/src/xpub/signing_client/mod.rs
@@ -1,7 +1,9 @@
+mod bitcoind;
 mod error;
 mod lnd;
 mod r#trait;
 
+pub use bitcoind::*;
 pub use error::*;
 pub use lnd::*;
 pub use r#trait::*;

--- a/tests/e2e/bitcoind_sync.bats
+++ b/tests/e2e/bitcoind_sync.bats
@@ -21,7 +21,7 @@ teardown_file() {
   bitcoind_signer_address=$(bitcoin_signer_cli getnewaddress)
   bria_address=$(bria_cmd new-address -w default | jq -r '.address')
 
-  [ "$bitcoind_signer_address" = "$bria_address" ]
+  [ "$bitcoind_signer_address" = "$bria_address" ] || exit 1
 
   n_addresses=$(bria_cmd list-addresses -w default | jq -r '.addresses | length')
   [ "$n_addresses" = "2" ] || exit 1
@@ -64,7 +64,7 @@ teardown_file() {
   n_utxos=$(jq '.keychains[0].utxos | length' <<< "${utxos}")
   utxo_block_height=$(jq -r '.keychains[0].utxos[0].blockHeight' <<< "${utxos}")
 
-  [[ "${n_utxos}" == "1" && "${utxo_block_height}" == "201" ]]
+  [[ "${n_utxos}" == "1" && "${utxo_block_height}" == "201" ]] || exit 1
 }
 
 @test "bitcoind_signer_sync: Detects outgoing transactions" {
@@ -82,7 +82,7 @@ teardown_file() {
   n_utxos=$(jq '.keychains[0].utxos | length' <<< "${utxos}")
   change=$(jq -r '.keychains[0].utxos[0].changeOutput' <<< "${utxos}")
 
-  [[ "${n_utxos}" == "1" && "${change}" == "true" ]]
+  [[ "${n_utxos}" == "1" && "${change}" == "true" ]] || exit 1
 
   bitcoin_cli -generate 1
 
@@ -97,7 +97,7 @@ teardown_file() {
   n_utxos=$(jq '.keychains[0].utxos | length' <<< "${utxos}")
   utxo_block_height=$(jq -r '.keychains[0].utxos[0].blockHeight' <<< "${utxos}")
 
-  [[ "${n_utxos}" == "1" && "${utxo_block_height}" == "203" ]]
+  [[ "${n_utxos}" == "1" && "${utxo_block_height}" == "203" ]] || exit 1
 }
 
 @test "bitcoind_signer_sync: Can handle spend from mix of unconfirmed UTXOs" {

--- a/tests/e2e/bitcoind_sync.bats
+++ b/tests/e2e/bitcoind_sync.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+
+load "helpers"
+
+setup_file() {
+  restart_bitcoin
+  reset_pg
+  bitcoind_with_signer_init
+  start_daemon
+  bria_init
+}
+
+teardown_file() {
+  stop_daemon
+}
+
+@test "bitcoind_signer_sync: Generates the same address" {
+  # Catchup to bitcoind_signer generated address from tpub import
+  bria_address=$(bria_cmd new-address -w default | jq -r '.address')
+
+  bitcoind_signer_address=$(bitcoin_signer_cli getnewaddress)
+  bria_address=$(bria_cmd new-address -w default | jq -r '.address')
+
+  [ "$bitcoind_signer_address" = "$bria_address" ]
+
+  n_addresses=$(bria_cmd list-addresses -w default | jq -r '.addresses | length')
+  [ "$n_addresses" = "2" ] || exit 1
+}
+
+@test "bitcoind_signer_sync: Detects incoming transactions" {
+  bitcoind_signer_address=$(bitcoin_signer_cli getnewaddress)
+  if [ -z "$bitcoind_signer_address" ]; then
+    echo "Failed to get a new address"
+    exit 1
+  fi
+
+  bitcoin_cli -regtest sendtoaddress ${bitcoind_signer_address} 1
+
+  for i in {1..30}; do
+    cache_default_wallet_balance
+    [[ $(cached_pending_income) == 100000000 ]] && break
+    sleep 1
+  done
+  [[ $(cached_pending_income) == 100000000 ]] || exit 1
+
+  n_addresses=$(bria_cmd list-addresses -w default | jq -r '.addresses | length')
+  [ "$n_addresses" = "3" ] || exit 1
+  utxos=$(bria_cmd list-utxos -w default)
+  n_utxos=$(jq '.keychains[0].utxos | length' <<< "${utxos}")
+  utxo_block_height=$(jq -r '.keychains[0].utxos[0].blockHeight' <<< "${utxos}")
+
+  [[ "${n_utxos}" == "1" && "${utxo_block_height}" == "null" ]]
+
+  bitcoin_cli -generate 2
+
+  for i in {1..30}; do
+    cache_default_wallet_balance
+    [[ $(cached_current_settled) == 100000000 ]] && break
+    sleep 1
+  done
+  [[ $(cached_current_settled) == 100000000 ]] || exit 1;
+
+  utxos=$(bria_cmd list-utxos -w default)
+  n_utxos=$(jq '.keychains[0].utxos | length' <<< "${utxos}")
+  utxo_block_height=$(jq -r '.keychains[0].utxos[0].blockHeight' <<< "${utxos}")
+
+  [[ "${n_utxos}" == "1" && "${utxo_block_height}" == "201" ]]
+}
+
+@test "bitcoind_signer_sync: Detects outgoing transactions" {
+  bitcoind_address=$(bitcoin_cli -regtest getnewaddress)
+  bitcoin_signer_cli -regtest sendtoaddress "${bitcoind_address}" 0.5
+  for i in {1..30}; do
+    cache_default_wallet_balance
+    [[ $(cached_pending_outgoing) == 50000000 ]] && break
+    sleep 1
+  done
+  [[ $(cached_pending_outgoing) == 50000000 ]] || exit 1
+  [[ $(cached_current_settled) == 0 ]] || exit 1
+
+  utxos=$(bria_cmd list-utxos -w default)
+  n_utxos=$(jq '.keychains[0].utxos | length' <<< "${utxos}")
+  change=$(jq -r '.keychains[0].utxos[0].changeOutput' <<< "${utxos}")
+
+  [[ "${n_utxos}" == "1" && "${change}" == "true" ]]
+
+  bitcoin_cli -generate 1
+
+  for i in {1..30}; do
+    cache_default_wallet_balance
+    [[ $(cached_current_settled) != 0 ]] && break
+    sleep 1
+  done
+  [[ $(cached_pending_outgoing) == 0 ]] || exit 1
+
+  utxos=$(bria_cmd list-utxos -w default)
+  n_utxos=$(jq '.keychains[0].utxos | length' <<< "${utxos}")
+  utxo_block_height=$(jq -r '.keychains[0].utxos[0].blockHeight' <<< "${utxos}")
+
+  [[ "${n_utxos}" == "1" && "${utxo_block_height}" == "203" ]]
+}
+
+@test "bitcoind_signer_sync: Can handle spend from mix of unconfirmed UTXOs" {
+  bitcoind_signer_address=$(bitcoin_signer_cli getnewaddress)
+  if [ -z "$bitcoind_signer_address" ]; then
+    echo "Failed to get a new address"
+    exit 1
+  fi
+
+  bitcoin_cli -regtest sendtoaddress ${bitcoind_signer_address} 1
+  bitcoin_cli -regtest sendtoaddress ${bitcoind_signer_address} 1
+
+  bitcoind_address=$(bitcoin_cli -regtest getnewaddress)
+  bitcoin_signer_cli -regtest sendtoaddress "${bitcoind_address}" 2.1
+
+  for i in {1..30}; do
+    cache_default_wallet_balance
+    [[ $(cached_pending_outgoing) == 210000000 ]] && break
+    sleep 1
+  done
+  [[ $(cached_pending_outgoing) == 210000000 ]] || exit 1
+  [[ $(cached_logical_settled) != 0 ]] || exit 1
+
+  bitcoin_cli -generate 2
+  for i in {1..30}; do
+    cache_default_wallet_balance
+    [[ $(cached_pending_outgoing) == 0 ]] && break
+    sleep 1
+  done
+
+  bitcoind_signer_balance_in_btc=$(bitcoin_signer_cli getbalance)
+  bitcoind_signer_balance=$(convert_btc_to_sats "${bitcoind_signer_balance_in_btc}")
+  if [[ "$(cached_logical_settled)" != "${bitcoind_signer_balance}" ]]; then
+    echo "$(cached_logical_settled)" != "${bitcoind_signer_balance}"
+    exit 1
+  fi
+}
+
+@test "bitcoind_signer_sync: Can sweep all" {
+  bitcoind_address=$(bitcoin_cli -regtest getnewaddress)
+  bitcoin_signer_cli -named sendall recipients="[\"${bitcoind_address}\"]" fee_rate=1
+  bitcoin_cli -generate 1
+
+  for i in {1..30}; do
+    cache_default_wallet_balance
+    [[ $(cached_encumbered_fees) == 0 ]] && break
+    sleep 1
+  done
+  [[ $(cached_encumbered_fees) == 0 ]] || exit 1
+  [[ $(cached_logical_settled) == 0 ]] || exit 1
+}
+
+@test "bitcoind_signer_sync: Can spend only from unconfirmed" {
+  bitcoind_signer_address=$(bitcoin_signer_cli getnewaddress)
+  bitcoin_cli -regtest sendtoaddress ${bitcoind_signer_address} 1
+  bitcoind_address=$(bitcoin_cli -regtest getnewaddress)
+  bitcoin_signer_cli -regtest sendtoaddress ${bitcoind_address} 0.6
+
+  for i in {1..30}; do
+    cache_default_wallet_balance
+    [[ $(cached_pending_outgoing) == 60000000 ]] && break
+    sleep 1
+  done
+  [[ $(cached_pending_outgoing) == 60000000 ]] || exit 1
+  [[ $(cached_logical_settled) == 0 ]] || exit 1
+
+  bitcoin_cli -generate 2
+  for i in {1..30}; do
+    cache_default_wallet_balance
+    [[ $(cached_pending_outgoing) == 0 ]] && break
+    sleep 1
+  done
+  [[ $(cached_pending_outgoing) == 0 ]] || exit 1
+  [[ $(cached_logical_settled) == $(cached_current_settled) ]] || exit 1
+  bitcoind_signer_balance_in_btc=$(bitcoind_signer_cli getbalance)
+  bitcoind_signer_balance=$(convert_btc_to_sats "${bitcoind_signer_balance_in_btc}")
+  [[ "$(cached_logical_settled)" == "${bitcoind_signer_balance}" ]] || exit 1
+}

--- a/tests/e2e/bitcoind_sync.bats
+++ b/tests/e2e/bitcoind_sync.bats
@@ -151,14 +151,21 @@ teardown_file() {
 
   for i in {1..30}; do
     cache_default_wallet_balance
-    [[ $(cached_encumbered_fees) == 0 ]] && break
+    echo "HERE 0: $balance"
+    [[ $(cached_pending_outgoing) == 0 ]] \
+      && [[ $(cached_encumbered_fees) == 0 ]] \
+      && break
     sleep 1
   done
+  cache_default_wallet_balance && echo "HERE 1: $balance"
   [[ $(cached_encumbered_fees) == 0 ]] || exit 1
   [[ $(cached_logical_settled) == 0 ]] || exit 1
+  [[ $(cached_pending_outgoing) == 0 ]] || exit 1
 }
 
 @test "bitcoind_signer_sync: Can spend only from unconfirmed" {
+  cache_default_wallet_balance && echo "HERE 2: $balance"
+
   bitcoind_signer_address=$(bitcoin_signer_cli getnewaddress)
   bitcoin_cli -regtest sendtoaddress ${bitcoind_signer_address} 1
   for i in {1..20}; do

--- a/tests/e2e/bitcoind_sync.bats
+++ b/tests/e2e/bitcoind_sync.bats
@@ -3,7 +3,7 @@
 load "helpers"
 
 setup_file() {
-  restart_bitcoin
+  restart_bitcoin_stack
   reset_pg
   bitcoind_with_signer_init
   start_daemon

--- a/tests/e2e/helpers.bash
+++ b/tests/e2e/helpers.bash
@@ -104,6 +104,12 @@ restart_bitcoin() {
 bitcoind_init() {
   bitcoin_cli createwallet "default" || true
   bitcoin_cli -generate 200
+
+  for i in {1..10}; do
+    bitcoind_balance=$(bitcoin_cli getbalance)
+    [[ ${bitcoind_balance} != "0.00000000" ]] && break
+  done
+  [[ ${bitcoind_balance} != "0.00000000" ]] || exit 1
 }
 
 bitcoind_with_signer_init() {

--- a/tests/e2e/helpers.bash
+++ b/tests/e2e/helpers.bash
@@ -6,6 +6,7 @@ if [[ "${BRIA_CONFIG}" == "docker" ]]; then
 fi
 BITCOIND_SIGNER_HOST="${BITCOIND_HOST:-localhost}"
 BITCOIND_SIGNER_ENDPOINT="https://${BITCOIND_SIGNER_HOST}:18543"
+SATS_IN_ONE_BTC=100000000
 
 bria_cmd() {
   bria_location=${REPO_ROOT}/target/debug/bria
@@ -54,6 +55,10 @@ bitcoin_cli() {
 
 bitcoin_signer_cli() {
   docker exec "${COMPOSE_PROJECT_NAME}-bitcoind-signer-1" bitcoin-cli $@
+}
+
+convert_btc_to_sats() {
+  echo "$1 * $SATS_IN_ONE_BTC / 1" | bc
 }
 
 lnd_cli() {

--- a/tests/e2e/lnd_sync.bats
+++ b/tests/e2e/lnd_sync.bats
@@ -18,18 +18,22 @@ teardown_file() {
   lnd_address=$(lnd_cli newaddress p2wkh | jq -r '.address')
   bria_address=$(bria_cmd new-address -w default | jq -r '.address')
 
-  [ "$lnd_address" = "$bria_address" ]
+  [ "$lnd_address" = "$bria_address" ] || exit 1
 
   n_addresses=$(bria_cmd list-addresses -w default | jq -r '.addresses | length')
   [ "$n_addresses" = "1" ] || exit 1
 }
 
 @test "lnd_sync: Detects incoming transactions" {
+  sleep 3
+  echo "HERE 1a: $(bria_cmd list-addresses -w default)"
+
   lnd_address=$(lnd_cli newaddress p2wkh | jq -r '.address')
   if [ -z "$lnd_address" ]; then
     echo "Failed to get a new address"
     exit 1
   fi
+  echo "HERE 1b: $lnd_address"
 
   bitcoin_cli -regtest sendtoaddress ${lnd_address} 1
 
@@ -41,7 +45,11 @@ teardown_file() {
   [[ $(cached_pending_income) == 100000000 ]] || exit 1
 
   n_addresses=$(bria_cmd list-addresses -w default | jq -r '.addresses | length')
-  [ "$n_addresses" = "2" ] || exit 1
+  if [ "$n_addresses" != "2" ]; then
+    echo "HERE 1c:"
+    bria_cmd list-addresses -w default
+    exit 1
+  fi
   utxos=$(bria_cmd list-utxos -w default)
   n_utxos=$(jq '.keychains[0].utxos | length' <<< "${utxos}")
   utxo_block_height=$(jq -r '.keychains[0].utxos[0].blockHeight' <<< "${utxos}")

--- a/tests/e2e/lnd_sync.bats
+++ b/tests/e2e/lnd_sync.bats
@@ -3,7 +3,7 @@
 load "helpers"
 
 setup_file() {
-  restart_bitcoin
+  restart_bitcoin_with_lnd
   reset_pg
   bitcoind_init
   start_daemon

--- a/tests/e2e/lnd_sync.bats
+++ b/tests/e2e/lnd_sync.bats
@@ -7,7 +7,7 @@ setup_file() {
   reset_pg
   bitcoind_init
   start_daemon
-  bria_init
+  bria_lnd_init
 }
 
 teardown_file() {

--- a/tests/e2e/payout.bats
+++ b/tests/e2e/payout.bats
@@ -5,7 +5,7 @@ load "helpers"
 setup_file() {
   restart_bitcoin
   reset_pg
-  bitcoind_init
+  bitcoind_with_signer_init
   start_daemon
   bria_init
 }
@@ -88,10 +88,9 @@ teardown_file() {
   cache_default_wallet_balance
   [[ $(cached_pending_income) == 0 ]] || exit 1
 
-  bitcoind_switch_to_signer_wallet
   bria_cmd set-signer-config \
     --xpub bitcoind_key bitcoind \
-    --endpoint "${BITCOIND_ENDPOINT}" \
+    --endpoint "${BITCOIND_SIGNER_ENDPOINT}" \
     --rpc-user "rpcuser" \
     --rpc-password "rpcpassword"
 
@@ -105,7 +104,6 @@ teardown_file() {
     echo "signing_status: ${signing_status}"
     echo "signing_failure_reason: ${signing_failure_reason}"
   fi
-  bitcoind_switch_to_default_wallet
 
   for i in {1..20}; do
     cache_default_wallet_balance

--- a/tests/e2e/payout.bats
+++ b/tests/e2e/payout.bats
@@ -97,9 +97,14 @@ teardown_file() {
 
   for i in {1..20}; do
     signing_status=$(bria_cmd list-signing-sessions -b "${batch_id}" | jq -r '.sessions[0].state')
-    [[ "${signing_status}" != "Complete" ]] && break
+    [[ "${signing_status}" == "Complete" ]] && break
     sleep 1
   done
+  if [[ "${signing_status}" != "Complete" ]]; then
+    signing_failure_reason=$(bria_cmd list-signing-sessions -b "${batch_id}" | jq -r '.sessions[0].failureReason')
+    echo "signing_status: ${signing_status}"
+    echo "signing_failure_reason: ${signing_failure_reason}"
+  fi
   bitcoind_switch_to_default_wallet
 
   for i in {1..20}; do

--- a/tests/e2e/payout.bats
+++ b/tests/e2e/payout.bats
@@ -3,7 +3,7 @@
 load "helpers"
 
 setup_file() {
-  restart_bitcoin
+  restart_bitcoin_stack
   reset_pg
   bitcoind_with_signer_init
   start_daemon

--- a/tests/e2e/payout.bats
+++ b/tests/e2e/payout.bats
@@ -75,19 +75,23 @@ teardown_file() {
 }
 
 @test "payout: Add signing config to complete payout" {
-    batch_id=$(bria_cmd list-payouts -w default | jq -r '.payouts[0].batchId')
-    for i in {1..20}; do
-      signing_failure_reason=$(bria_cmd list-signing-sessions -b "${batch_id}" | jq -r '.sessions[0].failureReason')
-      [[ "${signing_failure_reason}" == "SignerConfigMissing" ]] && break
-      sleep 1
-    done
+  batch_id=$(bria_cmd list-payouts -w default | jq -r '.payouts[0].batchId')
+  for i in {1..20}; do
+    signing_failure_reason=$(bria_cmd list-signing-sessions -b "${batch_id}" | jq -r '.sessions[0].failureReason')
+    [[ "${signing_failure_reason}" == "SignerConfigMissing" ]] && break
+    sleep 1
+  done
 
-    [[ "${signing_failure_reason}" == "SignerConfigMissing" ]] || exit 1
+  [[ "${signing_failure_reason}" == "SignerConfigMissing" ]] || exit 1
 
-    cache_default_wallet_balance
-    [[ $(cached_pending_income) == 0 ]] || exit 1
+  cache_default_wallet_balance
+  [[ $(cached_pending_income) == 0 ]] || exit 1
 
-    bria_cmd set-signer-config --xpub lnd_key lnd --endpoint "${LND_ENDPOINT}" --macaroon-file "./dev/lnd/regtest/lnd.admin.macaroon" --cert-file "./dev/lnd/tls.cert"
+  bria_cmd set-signer-config \
+    --xpub lnd_key lnd \
+    --endpoint "${LND_ENDPOINT}" \
+    --macaroon-file "./dev/lnd/regtest/lnd.admin.macaroon" \
+    --cert-file "./dev/lnd/tls.cert"
 
   for i in {1..20}; do
     signing_status=$(bria_cmd list-signing-sessions -b "${batch_id}" | jq -r '.sessions[0].state')


### PR DESCRIPTION
## Description

This PR will add a remote signer to sign psbt's from a bitcoind wallet.

### Open `TODO`s
- [x] **Import xpub from `bitcoind`**
  This is done by calling:
  - `bitcoin-cli getnewaddress`
  - `bitcoin-cli getaddressinfo <new-address>`
  - reading the `parent_desc` off the json return and importing the tpub from there into bria

- [x] **Test that signing config can be imported**

- [x] **Add payout via bitcoind to e2e tests and iterate to confirm signer works**