### PR TITLE
chore: change rpc defaults

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -943,8 +943,8 @@ async fn run_cmd(
                             xpub,
                             SetSignerConfigCommand::Bitcoind {
                                 endpoint: signer_endpoint,
-                                rpc_user: dev_constants::DEFAULT_BITOIND_RPC_USER.to_string(),
-                                rpc_password: dev_constants::DEFAULT_BITOIND_RPC_PASSWORD
+                                rpc_user: dev_constants::DEFAULT_BITCOIND_RPC_USER.to_string(),
+                                rpc_password: dev_constants::DEFAULT_BITCOIND_RPC_PASSWORD
                                     .to_string(),
                             },
                         )

--- a/src/dev_constants.rs
+++ b/src/dev_constants.rs
@@ -4,5 +4,5 @@ pub const DEV_QUEUE_NAME: &str = "dev";
 pub const BRIA_DEV_KEY: &str = "bria_dev_000000000000000000000";
 pub const DEV_SIGNER_ENCRYPTION_KEY: &str =
     "0000000000000000000000000000000000000000000000000000000000000000";
-pub const DEFAULT_BITOIND_RPC_USER: &str = "rpc_user";
-pub const DEFAULT_BITOIND_RPC_PASSWORD: &str = "rpc_password";
+pub const DEFAULT_BITCOIND_RPC_USER: &str = "rpcuser";
+pub const DEFAULT_BITCOIND_RPC_PASSWORD: &str = "rpcpassword";


### PR DESCRIPTION
## Description

The rpc defaults are usually `rpcuser` and `rpcpassword`