### PR TITLE
fix: update max payout field name

### DIFF
--- a/tests/payout.rs
+++ b/tests/payout.rs
@@ -93,7 +93,7 @@ async fn spending_policy() -> anyhow::Result<()> {
             wallet_name.clone(),
             Some(SpendingPolicy {
                 allowed_payout_addresses: vec![address.clone()],
-                maximum_payout: Some(Satoshis::from(10000)),
+                max_payout: Some(Satoshis::from(10000)),
             }),
         )
         .await?;


### PR DESCRIPTION
Updates a field name missed in https://github.com/GaloyMoney/bria/commit/6ebd118e3d21731343867cb3381c7b11b6413146