### PR TITLE
ci: remove slack notifications

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,9 +16,6 @@
 #@   "rust_task_image_config",
 #@   "charts_repo_resource",
 #@   "charts_repo_bot_branch",
-#@   "slack_resource_type",
-#@   "slack_resource",
-#@   "slack_failure_notification"
 #@ )
 
 groups:
@@ -294,7 +291,6 @@ jobs:
 resources:
 - #@ repo_resource(True)
 - #@ pipeline_tasks_resource()
-- #@ slack_resource()
 - #@ version_resource()
 - #@ gh_release_resource()
 - #@ edge_image_resource()
@@ -308,6 +304,3 @@ resources:
 - #@ charts_repo_resource()
 - #@ charts_repo_bot_branch()
 - #@ docker_host_pool()
-
-resource_types:
-- #@ slack_resource_type()

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -26,7 +26,3 @@ staging_ssh_pub_key: ((staging-ssh.ssh_public_key))
 git_version_branch: version
 gh_org: GaloyMoney
 gh_repository: bria
-
-slack_channel: bria-github
-slack_username: concourse
-slack_webhook_url: ((addons-slack.api_url))

--- a/ci/vendor/pipeline-fragments.lib.yml
+++ b/ci/vendor/pipeline-fragments.lib.yml
@@ -50,16 +50,6 @@ source:
   repository: nixpkgs/nix-flakes
 #@ end
 
-#@ def slack_failure_notification():
-#@ fail_url = "<$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME| :face_with_symbols_on_mouth: $BUILD_JOB_NAME> failed!"
-put: slack
-params:
-  channel:  #@ data.values.slack_channel
-  username: concourse
-  icon_url: https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png
-  text:    #@ fail_url
-#@ end
-
 #@ def check_code():
 name: check-code
 serial: true
@@ -76,7 +66,6 @@ plan:
     - name: repo
     run:
       path: pipeline-tasks/ci/vendor/tasks/check-code.sh
-on_failure: #@ slack_failure_notification()
 #@ end
 
 #@ def nodejs_check_code():
@@ -97,7 +86,6 @@ plan:
     - name: repo
     run:
       path: pipeline-tasks/ci/vendor/tasks/nodejs-check-code.sh
-on_failure: #@ slack_failure_notification()
 #@ end
 
 #@ def rust_check_code():
@@ -119,7 +107,6 @@ plan:
     - path: cargo-target-dir
     run:
       path: pipeline-tasks/ci/vendor/tasks/rust-check-code.sh
-on_failure: #@ slack_failure_notification()
 #@ end
 
 #@ def install_yarn_deps():
@@ -144,7 +131,6 @@ plan:
 - put: bundled-deps
   params:
     file: bundled-deps/bundled-deps-*.tgz
-on_failure: #@ slack_failure_notification()
 #@ end
 
 #@ def test_on_docker_host(container, additional_params={}):
@@ -184,7 +170,6 @@ plan:
     put: docker-host
     params:
       release: docker-host
-on_failure: #@ slack_failure_notification()
 #@ end
 
 #@ def nodejs_integration_test():
@@ -215,7 +200,6 @@ plan:
       JEST_TIMEOUT: 90000
     run:
       path: pipeline-tasks/ci/vendor/tasks/chart-test-integration.sh
-on_failure: #@ slack_failure_notification()
 #@ end
 
 #@ def rust_integration_test():
@@ -246,7 +230,6 @@ plan:
       SSH_PUB_KEY: ((staging-ssh.ssh_public_key))
     run:
       path: pipeline-tasks/ci/vendor/tasks/chart-test-integration.sh
-on_failure: #@ slack_failure_notification()
 #@ end
 
 #@ def nodejs_audit(level = "high"):
@@ -268,7 +251,6 @@ plan:
       REPO_ROOT: repo
     run:
       path: pipeline-tasks/ci/vendor/tasks/nodejs-audit.sh
-on_failure: #@ slack_failure_notification()
 #@ end
 
 #@ def build_edge_image():
@@ -481,13 +463,6 @@ source:
   regexp: #@ data.values.gh_repository + "-artifacts/deps/bundled-deps-v(.*)-.*.tgz"
 #@ end
 
-#@ def slack_resource():
-name: slack
-type: slack-notification
-source:
-  url: #@ data.values.slack_webhook_url
-#@ end
-
 #@ def version_resource():
 name: version
 type: semver
@@ -551,13 +526,6 @@ name: gcs-resource
 type: docker-image
 source:
   repository: frodenas/gcs-resource
-#@ end
-
-#@ def slack_resource_type():
-name: slack-notification
-type: docker-image
-source:
-  repository: cfcommunity/slack-notification-resource
 #@ end
 
 #@ def npm_resource_type():


### PR DESCRIPTION
The deployed changes with:
```
./ci/repipe
```
have a diff outside of the changes here as follows:
```
Updating pipeline @ galoy
resources:
  resource slack has been removed:
- name: slack
- source:
-   url: ((addons-slack.api_url))
- type: slack-notification
  
resource types:
  resource type slack-notification has been removed:
- name: slack-notification
- source:
-   repository: cfcommunity/slack-notification-resource
- type: docker-image
  
jobs:
  job check-code has changed:
  name: check-code
- on_failure:
-   params:
-     channel: bria-github
-     icon_url: https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png
-     text: '<$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|
-       :face_with_symbols_on_mouth: $BUILD_JOB_NAME> failed!'
-     username: concourse
-   put: slack
  plan:
  - in_parallel:
      steps:
      - get: repo
        trigger: true
      - get: pipeline-tasks
  - config:
      caches:
      - path: cargo-home
      - path: cargo-target-dir
      image_resource:
        name: ""
        source:
          password: ((docker-creds.password))
          repository: us.gcr.io/galoy-org/rust-concourse
          username: ((docker-creds.username))
        type: registry-image
      inputs:
      - name: pipeline-tasks
      - name: repo
      platform: linux
      run:
        path: pipeline-tasks/ci/vendor/tasks/rust-check-code.sh
    task: check-code
  serial: true
  
  job build-edge-image has changed:
  name: build-edge-image
  plan:
  - in_parallel:
      steps:
      - get: repo
        trigger: true
      - get: pipeline-tasks
  - config:
      image_resource:
        name: ""
        source:
          password: ((docker-creds.password))
          repository: us.gcr.io/galoy-org/nodejs-concourse
          username: ((docker-creds.username))
        type: registry-image
      inputs:
      - name: pipeline-tasks
      - name: repo
      outputs:
      - name: repo
      platform: linux
      run:
        path: pipeline-tasks/ci/vendor/tasks/docker-prep-docker-build-env.sh
    task: prepare-docker-build
  - config:
      image_resource:
        name: ""
        source:
-         repository: vito/oci-build-task
+         repository: gcr.io/kaniko-project/executor
+         tag: debug
        type: registry-image
      inputs:
      - name: repo
      outputs:
      - name: image
-     params:
-       CONTEXT: repo
      platform: linux
      run:
-       path: build
-   privileged: true
+       args:
+       - --dockerfile=Dockerfile
+       - --context=repo
+       - --use-new-run
+       - --single-snapshot
+       - --cache=false
+       - --no-push
+       - --tar-path=image/image.tar
+       path: /kaniko/executor
    task: build
  - params:
      image: image/image.tar
    put: edge-image
  serial: true
  
  job integration-tests has changed:
  name: integration-tests
- on_failure:
-   params:
-     channel: bria-github
-     icon_url: https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png
-     text: '<$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|
-       :face_with_symbols_on_mouth: $BUILD_JOB_NAME> failed!'
-     username: concourse
-   put: slack
  plan:
  - params:
      acquire: true
    put: docker-host
  - in_parallel:
      steps:
      - get: repo
        trigger: true
      - get: pipeline-tasks
  - attempts: 2
    config:
      caches:
      - path: cargo-home
      - path: cargo-target-dir
      image_resource:
        name: ""
        source:
          password: ((docker-creds.password))
          repository: us.gcr.io/galoy-org/rust-concourse
          username: ((docker-creds.username))
        type: registry-image
      inputs:
      - name: pipeline-tasks
      - name: docker-host
      - name: repo
        path: bria-integration-tests
      params:
        GOOGLE_CREDENTIALS: ((staging-gcp-creds.creds_json))
        JEST_TIMEOUT: "90000"
        REPO_PATH: bria-integration-tests
        SSH_PRIVATE_KEY: ((staging-ssh.ssh_private_key))
        SSH_PUB_KEY: ((staging-ssh.ssh_public_key))
        TEST_CONTAINER: integration-tests
      platform: linux
      run:
        path: pipeline-tasks/ci/vendor/tasks/test-on-docker-host.sh
    ensure:
      params:
        release: docker-host
      put: docker-host
    tags:
    - galoy-staging
    task: integration-tests
    timeout: 12m
  serial: true
  
  job e2e-tests has changed:
  name: e2e-tests
- on_failure:
-   params:
-     channel: bria-github
-     icon_url: https://cl.ly/2F421Y300u07/concourse-logo-blue-transparent.png
-     text: '<$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|
-       :face_with_symbols_on_mouth: $BUILD_JOB_NAME> failed!'
-     username: concourse
-   put: slack
  plan:
  - params:
      acquire: true
    put: docker-host
  - in_parallel:
      steps:
      - get: repo
        trigger: true
      - get: pipeline-tasks
  - attempts: 2
    config:
      caches:
      - path: cargo-home
      - path: cargo-target-dir
      image_resource:
        name: ""
        source:
          password: ((docker-creds.password))
          repository: us.gcr.io/galoy-org/rust-concourse
          username: ((docker-creds.username))
        type: registry-image
      inputs:
      - name: pipeline-tasks
      - name: docker-host
      - name: repo
        path: bria-e2e-tests
      params:
        GOOGLE_CREDENTIALS: ((staging-gcp-creds.creds_json))
        JEST_TIMEOUT: "90000"
        REPO_PATH: bria-e2e-tests
        SSH_PRIVATE_KEY: ((staging-ssh.ssh_private_key))
        SSH_PUB_KEY: ((staging-ssh.ssh_public_key))
        TEST_CONTAINER: e2e-tests
      platform: linux
      run:
        path: pipeline-tasks/ci/vendor/tasks/test-on-docker-host.sh
    ensure:
      params:
        release: docker-host
      put: docker-host
    tags:
    - galoy-staging
    task: e2e-tests
    timeout: 12m
  serial: true
  
pipeline name: bria
```