### PR TITLE
fix: udpate bdk_transactions sent type

### DIFF
--- a/migrations/20250515172604_update_bdk_transactions_sent.down.sql
+++ b/migrations/20250515172604_update_bdk_transactions_sent.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/migrations/20250515172604_update_bdk_transactions_sent.up.sql
+++ b/migrations/20250515172604_update_bdk_transactions_sent.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bdk_transactions
+ALTER COLUMN sent TYPE BIGINT;


### PR DESCRIPTION
we use i64 `builder.push_bind(tx.sent as i64);` so the type is not compatible