### PR TITLE
fix: use entity_id macro from es_entity

### DIFF
--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,3 +1,4 @@
+use es_entity::entity_id;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -21,13 +22,12 @@ impl From<AccountId> for LedgerJournalId {
         Self::from(uuid::Uuid::from(id))
     }
 }
-crate::entity_id! { ProfileId }
+entity_id! { ProfileId, PayoutQueueId }
 crate::entity_id! { ProfileApiKeyId }
 crate::entity_id! { SigningSessionId }
 crate::entity_id! { KeychainId }
 crate::entity_id! { SignerId }
 crate::entity_id! { WalletId }
-crate::entity_id! { PayoutQueueId }
 crate::entity_id! { PayoutId }
 
 impl From<PayoutId> for LedgerTransactionId {


### PR DESCRIPTION
uses the entity_id macro for entity ids of profile and payoutqueueId, earlier the macro from existing entity module was used