### PR TITLE
feat: integrate crane library and enhance Rust build configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install-dev-deps:
 	cargo install cargo-nextest cargo-watch cargo-audit sqlx-cli
 
 build:
-	SQLX_OFFLINE=true cargo build --locked
+	nix build
 
 watch:
 	RUST_BACKTRACE=full cargo watch -s 'cargo test -- --nocapture'
@@ -14,13 +14,11 @@ test-integration: reset-deps
 	cargo nextest run --verbose --locked
 
 check-code:
-	SQLX_OFFLINE=true cargo fmt --check --all
-	SQLX_OFFLINE=true cargo clippy --all-features
-	SQLX_OFFLINE=true cargo audit
+	nix build .#check-code
 
 local-daemon:
 	SIGNER_ENCRYPTION_KEY="0000000000000000000000000000000000000000000000000000000000000000" \
-														cargo run --bin bria daemon --config ./bats/bria.local.yml run
+cargo run --bin bria daemon --config ./bats/bria.local.yml run
 
 build-x86_64-unknown-linux-musl-release:
 	SQLX_OFFLINE=true cargo build --release --locked --target x86_64-unknown-linux-musl
@@ -54,3 +52,17 @@ e2e-tests-in-container:
 
 e2e: clean-deps build start-deps
 	bats -t bats
+
+# Nix convenience targets
+nix-build:
+	nix build
+
+nix-shell:
+	nix develop
+
+nix-show:
+	nix flake show
+
+# Run the application
+run:
+	nix run

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,28 @@
 install-dev-deps:
-	cargo install cargo-nextest cargo-watch cargo-audit sqlx-cli
+	nix develop -c cargo install cargo-nextest cargo-watch cargo-audit sqlx-cli
 
 build:
 	nix build
 
 watch:
-	RUST_BACKTRACE=full cargo watch -s 'cargo test -- --nocapture'
+	nix develop -c bash -c 'RUST_BACKTRACE=full cargo watch -s "cargo test -- --nocapture"'
 
 next-watch:
-	cargo watch -s 'cargo nextest run'
+	nix develop -c cargo watch -s 'cargo nextest run'
 
 test-integration: reset-deps
-	cargo nextest run --verbose --locked
+	nix develop -c cargo nextest run --verbose --locked
 
 check-code:
-	SQLX_OFFLINE=true cargo fmt --check --all
-	SQLX_OFFLINE=true cargo clippy --all-features
-	SQLX_OFFLINE=true cargo audit
+	nix develop -c bash -c 'SQLX_OFFLINE=true cargo fmt --check --all'
+	nix develop -c bash -c 'SQLX_OFFLINE=true cargo clippy --all-features'
+	nix develop -c cargo audit
 	
 local-daemon:
 	nix run .#local-daemon
 
 build-x86_64-unknown-linux-musl-release:
-	SQLX_OFFLINE=true cargo build --release --locked --target x86_64-unknown-linux-musl
+	nix develop -c bash -c 'SQLX_OFFLINE=true cargo build --release --locked --target x86_64-unknown-linux-musl'
 
 build-x86_64-apple-darwin-release:
 	bin/osxcross-compile.sh
@@ -36,21 +36,21 @@ start-deps:
 reset-deps: clean-deps start-deps setup-db
 
 setup-db:
-	cargo sqlx migrate run
+	nix develop -c cargo sqlx migrate run
 
 integration-tests-in-container:
-	DATABASE_URL=postgres://user:password@postgres:5432/pg cargo sqlx migrate run
-	DATABASE_URL=postgres://user:password@postgres:5432/pg cargo nextest run --verbose --locked
+	nix develop -c bash -c 'DATABASE_URL=postgres://user:password@postgres:5432/pg cargo sqlx migrate run'
+	nix develop -c bash -c 'DATABASE_URL=postgres://user:password@postgres:5432/pg cargo nextest run --verbose --locked'
 
 test-in-ci: start-deps
-	DATABASE_URL=postgres://user:password@127.0.0.1:5432/pg cargo sqlx migrate run
-	DATABASE_URL=postgres://user:password@127.0.0.1:5432/pg cargo nextest run --verbose --locked
+	nix develop -c bash -c 'DATABASE_URL=postgres://user:password@127.0.0.1:5432/pg cargo sqlx migrate run'
+	nix develop -c bash -c 'DATABASE_URL=postgres://user:password@127.0.0.1:5432/pg cargo nextest run --verbose --locked'
 
 e2e-tests-in-container:
 	git config --global --add safe.directory /repo # otherwise bats complains
-	SQLX_OFFLINE=true cargo build --locked
-	bats -t bats
+	nix develop -c bash -c 'SQLX_OFFLINE=true cargo build --locked'
+	nix develop -c bats -t bats
 
 e2e: clean-deps build start-deps
-	bats -t bats
+	nix develop -c bats -t bats
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ next-watch:
 test-integration: reset-deps
 	cargo nextest run --verbose --locked
 
+check-code:
+	SQLX_OFFLINE=true cargo fmt --check --all
+	SQLX_OFFLINE=true cargo clippy --all-features
+	SQLX_OFFLINE=true cargo audit
+	
 local-daemon:
 	nix run .#local-daemon
 

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,8 @@ next-watch:
 test-integration: reset-deps
 	cargo nextest run --verbose --locked
 
-check-code:
-	nix build .#check-code
-
 local-daemon:
-	SIGNER_ENCRYPTION_KEY="0000000000000000000000000000000000000000000000000000000000000000" \
-cargo run --bin bria daemon --config ./bats/bria.local.yml run
+	nix run .#local-daemon
 
 build-x86_64-unknown-linux-musl-release:
 	SQLX_OFFLINE=true cargo build --release --locked --target x86_64-unknown-linux-musl

--- a/Makefile
+++ b/Makefile
@@ -49,16 +49,3 @@ e2e-tests-in-container:
 e2e: clean-deps build start-deps
 	bats -t bats
 
-# Nix convenience targets
-nix-build:
-	nix build
-
-nix-shell:
-	nix develop
-
-nix-show:
-	nix flake show
-
-# Run the application
-run:
-	nix run

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,12 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=migrations");
 
-    std::env::set_var("PROTOC", protobuf_src::protoc());
+    if std::env::var("PROTOC").ok().is_some() {
+        println!("Using PROTOC set in environment.");
+    } else {
+        println!("Setting PROTOC to protoc-bin-vendored version.");
+        std::env::set_var("PROTOC", protobuf_src::protoc());
+    }
 
     tonic_build::configure()
         .type_attribute(".", "#[derive(serde::Serialize)]")

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1750266157,
+        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -20,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
+        "lastModified": 1750365781,
+        "narHash": "sha256-XE/lFNhz5lsriMm/yjXkvSZz5DfvKJLUjsS6pP8EC50=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
+        "rev": "08f22084e6085d19bcfb4be30d1ca76ecb96fe54",
         "type": "github"
       },
       "original": {
@@ -36,6 +51,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
@@ -48,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747332411,
-        "narHash": "sha256-2LOxMLddhMoJphMU/72Ls6Rvp38aJUrp7OhWwyvslek=",
+        "lastModified": 1750387093,
+        "narHash": "sha256-MgL1+yNVcSD6OlzSmKt5GS4RmAQnNCjckjgPC1hmMPg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "10d4529b7ead35863caa77993915104345524bed",
+        "rev": "517e9871d182346b53bb7f23fed00810c14db396",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,6 @@
           || pkgs.lib.hasInfix "/proto/" path
           || pkgs.lib.hasInfix "/.sqlx/" path;
       };
-      
       commonArgs = {
         src = rustSource;
         strictDeps = true;
@@ -68,11 +67,21 @@
         PROTOC_INCLUDE = "${pkgs.protobuf}/include";
       };
       
+      cargoVendorDir = craneLib.vendorCargoDeps {
+        inherit (commonArgs) src cargoLock;
+
+        outputHashes = {
+          "git+https://github.com/HyperparamAI/sqlxmq?rev=52c3daf6af55416aefa4b1114e108f968f6c57d4#52c3daf6af55416aefa4b1114e108f968f6c57d4" = "sha256-nYD3c/Pj95bOHHhFS+rdXVpJgFl9BkVmWZ05/Dot6rY=";
+        };
+
+      };
+      
       cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
         pname = "bria-deps";
         version = "0.0.0";
+        cargoVendorDir = cargoVendorDir;     
         
-        configurePhase = ''
+        preConfigure = ''
           export CARGO_NET_GIT_FETCH_WITH_CLI=true
           export PROTOC="${pkgs.protobuf}/bin/protoc"
           export PATH="${pkgs.protobuf}/bin:${pkgs.gitMinimal}/bin:${pkgs.coreutils}/bin:$PATH"
@@ -84,9 +93,10 @@
       
       bria = craneLib.buildPackage (commonArgs // {
         inherit cargoArtifacts;
+        cargoVendorDir = cargoVendorDir;     
         doCheck = false;
         
-        configurePhase = ''
+        preConfigure = ''
           export CARGO_NET_GIT_FETCH_WITH_CLI=true
           export PROTOC="${pkgs.protobuf}/bin/protoc"
           export PATH="${pkgs.protobuf}/bin:${pkgs.gitMinimal}/bin:${pkgs.coreutils}/bin:$PATH"

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
           export PATH="${pkgs.protobuf}/bin:${pkgs.gitMinimal}/bin:${pkgs.coreutils}/bin:$PATH"
           export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
           export CARGO_HTTP_CAINFO="$SSL_CERT_FILE"
+          export GIT_SSL_CAINFO="$SSL_CERT_FILE"
         '';
       });
       
@@ -91,6 +92,7 @@
           export PATH="${pkgs.protobuf}/bin:${pkgs.gitMinimal}/bin:${pkgs.coreutils}/bin:$PATH"
           export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
           export CARGO_HTTP_CAINFO="$SSL_CERT_FILE"
+          export GIT_SSL_CAINFO="$SSL_CERT_FILE"
         '';
       });
       
@@ -115,6 +117,7 @@
           export PATH="${pkgs.protobuf}/bin:${pkgs.gitMinimal}/bin:${pkgs.coreutils}/bin:$PATH"
           export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
           export CARGO_HTTP_CAINFO="$SSL_CERT_FILE"
+          export GIT_SSL_CAINFO="$SSL_CERT_FILE"
         '';
         
         buildPhaseCargoCommand = "check";

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    crane.url = "github:ipetkov/crane";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs = {
@@ -15,6 +16,7 @@
     self,
     nixpkgs,
     flake-utils,
+    crane,
     rust-overlay,
   }:
     flake-utils.lib.eachDefaultSystem
@@ -23,10 +25,107 @@
       pkgs = import nixpkgs {
         inherit system overlays;
       };
+      
       rustVersion = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
       rustToolchain = rustVersion.override {
-        extensions = ["rust-analyzer" "rust-src"];
+        extensions = ["rust-analyzer" "rust-src" "rustfmt" "clippy"];
       };
+      
+      craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+      rustSource = pkgs.lib.cleanSourceWith {
+        src = ./.;
+        filter = path: type:
+          craneLib.filterCargoSources path type
+          || pkgs.lib.hasInfix "/migrations/" path
+          || pkgs.lib.hasInfix "/proto/" path
+          || pkgs.lib.hasInfix "/.sqlx/" path;
+      };
+      
+      commonArgs = {
+        src = rustSource;
+        strictDeps = true;
+        cargoToml = ./Cargo.toml;
+        cargoLock = ./Cargo.lock;
+        
+        buildInputs = with pkgs; [
+          protobuf
+        ] ++ lib.optionals pkgs.stdenv.isDarwin [
+          darwin.apple_sdk.frameworks.SystemConfiguration
+        ];
+        
+        nativeBuildInputs = with pkgs; [
+          protobuf
+          pkg-config
+          cmake
+          cacert
+          gitMinimal
+          coreutils
+        ];
+        
+        SQLX_OFFLINE = true;
+        PROTOC = "${pkgs.protobuf}/bin/protoc";
+        PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+      };
+      
+      cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
+        pname = "bria-deps";
+        version = "0.0.0";
+        
+        configurePhase = ''
+          export CARGO_NET_GIT_FETCH_WITH_CLI=true
+          export PROTOC="${pkgs.protobuf}/bin/protoc"
+          export PATH="${pkgs.protobuf}/bin:${pkgs.gitMinimal}/bin:${pkgs.coreutils}/bin:$PATH"
+          export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+          export CARGO_HTTP_CAINFO="$SSL_CERT_FILE"
+        '';
+      });
+      
+      bria = craneLib.buildPackage (commonArgs // {
+        inherit cargoArtifacts;
+        doCheck = false;
+        
+        configurePhase = ''
+          export CARGO_NET_GIT_FETCH_WITH_CLI=true
+          export PROTOC="${pkgs.protobuf}/bin/protoc"
+          export PATH="${pkgs.protobuf}/bin:${pkgs.gitMinimal}/bin:${pkgs.coreutils}/bin:$PATH"
+          export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+          export CARGO_HTTP_CAINFO="$SSL_CERT_FILE"
+        '';
+      });
+      
+      checkCode = craneLib.mkCargoDerivation {
+        pname = "check-code";
+        version = "0.1.0";
+        src = rustSource;
+        cargoToml = ./Cargo.toml;
+        cargoLock = ./Cargo.lock;
+        inherit cargoArtifacts;
+        SQLX_OFFLINE = true;
+        
+        nativeBuildInputs = with pkgs; [
+          protobuf
+          cacert
+          cargo-audit
+        ];
+        
+        configurePhase = ''
+          export CARGO_NET_GIT_FETCH_WITH_CLI=true
+          export PROTOC="${pkgs.protobuf}/bin/protoc"
+          export PATH="${pkgs.protobuf}/bin:${pkgs.gitMinimal}/bin:${pkgs.coreutils}/bin:$PATH"
+          export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+          export CARGO_HTTP_CAINFO="$SSL_CERT_FILE"
+        '';
+        
+        buildPhaseCargoCommand = "check";
+        buildPhase = ''
+          cargo fmt --check --all
+          cargo clippy --all-features
+          cargo audit
+        '';
+        installPhase = "touch $out";
+      };
+      
       nativeBuildInputs = with pkgs;
         [
           rustToolchain
@@ -45,6 +144,30 @@
       };
     in
       with pkgs; {
+        packages = {
+          default = bria;
+          bria = bria;
+          check-code = checkCode;
+        };
+        
+        checks = {
+          inherit bria;
+          check-code = checkCode;
+          
+          bria-clippy = craneLib.cargoClippy (commonArgs // {
+            inherit cargoArtifacts;
+            cargoClippyExtraArgs = "--lib --bins -- --deny warnings";
+          });
+          
+          bria-fmt = craneLib.cargoFmt {
+            inherit (commonArgs) src;
+          };
+        };
+        
+        apps.default = flake-utils.lib.mkApp {
+          drv = bria;
+        };
+
         devShells.default = mkShell (devEnvVars
           // {
             inherit nativeBuildInputs;


### PR DESCRIPTION

 This PR integrates the Crane library into Bria’s Nix setup and strengthens the Rust build/check pipeline around reproducible package builds and repository-level checks.

  Implemented in this PR:
  - added Crane as a flake input
  - expanded `flake.nix` to build Rust dependencies separately and then build the package via Crane
  - introduced package/check outputs for the Rust project in Nix
  - wired in repo-level checks such as formatting, clippy, and audit within the Nix build flow
  - updated `Makefile` and `build.rs`-related configuration to fit the new build path

