### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+Only the latest release and `main` receive security fixes.
+
+Please report security vulnerabilities by email to **security@galoy.io** —
+do not report them through public GitHub issues, discussions, or pull requests.


### PR DESCRIPTION
Adds a minimal `SECURITY.md` so GitHub surfaces a security policy for this
repo, pointing reporters at **security@galoy.io**.

Part of an effort to add a consistent security policy across Galoy's open
source repositories (obix, job, es-entity, cala, bria, drua).
